### PR TITLE
Add window end time in schema_df

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ Data processing parameters include:
 - `batch_mode`: Whether to return sequences at the _measurement_ level (`"SM"`) or the _event_ level
     (`"SEM"`). Note that here, we use "_measurement_" to refer to a single row (observation) in the raw MEDS
     data, and "_event_" to refer to all measurements taken at a single time-point.
+- `return_last_time`: If `True`, include the timestamp of the last observation in each sampled window in
+  the dataset's `schema_df` when an index dataframe is used and the sampling strategy is deterministic.
 
 Of these, `seq_sampling_strategy` and `static_inclusion_mode` are restricted, and must be of the
 [`SubsequenceSamplingStrategy`](https://meds-torch-data.readthedocs.io/en/latest/api/meds_torchdata/config/#meds_torchdata.config.SubsequenceSamplingStrategy)

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Data processing parameters include:
     (`"SEM"`). Note that here, we use "_measurement_" to refer to a single row (observation) in the raw MEDS
     data, and "_event_" to refer to all measurements taken at a single time-point.
 - `return_last_time`: If `True`, include the timestamp of the last observation in each sampled window in
-  the dataset's `schema_df` when an index dataframe is used and the sampling strategy is deterministic.
+    the dataset's `schema_df` when an index dataframe is used and the sampling strategy is deterministic.
 
 Of these, `seq_sampling_strategy` and `static_inclusion_mode` are restricted, and must be of the
 [`SubsequenceSamplingStrategy`](https://meds-torch-data.readthedocs.io/en/latest/api/meds_torchdata/config/#meds_torchdata.config.SubsequenceSamplingStrategy)

--- a/README.md
+++ b/README.md
@@ -182,8 +182,10 @@ Data processing parameters include:
 - `batch_mode`: Whether to return sequences at the _measurement_ level (`"SM"`) or the _event_ level
     (`"SEM"`). Note that here, we use "_measurement_" to refer to a single row (observation) in the raw MEDS
     data, and "_event_" to refer to all measurements taken at a single time-point.
-- `return_last_time`: If `True`, include the timestamp of the last observation in each sampled window in
-    the dataset's `schema_df` when an index dataframe is used and the sampling strategy is deterministic.
+- `include_window_end_time_in_schema`: If `True`, include the timestamp of the last observation in each
+    sampled window in the dataset's `schema_df` when an index dataframe is used and the sampling strategy is
+    deterministic. This functionality is useful for generative applications where the model needs to know what
+    the timestamp is at the start of a generation window, for example.
 
 Of these, `seq_sampling_strategy` and `static_inclusion_mode` are restricted, and must be of the
 [`SubsequenceSamplingStrategy`](https://meds-torch-data.readthedocs.io/en/latest/api/meds_torchdata/config/#meds_torchdata.config.SubsequenceSamplingStrategy)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,12 +21,12 @@ classifiers = [
 ]
 dependencies = [
     "pytest",
-    "polars",
+    "polars~=1.30.0",
     "nested_ragged_tensors>=0.1.0",
     "numpy",
     "torch",
     "meds~=0.4.0",
-    "MEDS_transforms~=0.5.0",
+    "MEDS_transforms~=0.5.2",
     "hydra-core",
     "omegaconf",
     "meds_testing_helpers>=0.3.0"

--- a/src/meds_torchdata/config.py
+++ b/src/meds_torchdata/config.py
@@ -125,7 +125,7 @@ class MEDSTorchDataConfig:
     batch_mode: BatchMode = BatchMode.SM
 
     # Extra output
-    include_window_end_time_in_schema: bool = False
+    include_window_last_observed_in_schema: bool = False
 
     @classmethod
     def add_to_config_store(cls, group: str | None = None):
@@ -146,7 +146,7 @@ class MEDSTorchDataConfig:
                              'static_inclusion_mode': <StaticInclusionMode.INCLUDE: 'include'>,
                              'task_labels_dir': None,
                              'batch_mode': <BatchMode.SM: 'SM'>,
-                             'include_window_end_time_in_schema': False,
+                             'include_window_last_observed_in_schema': False,
                              '_target_': 'meds_torchdata.config.MEDSTorchDataConfig'},
                        group=None,
                        package=None,
@@ -169,7 +169,7 @@ class MEDSTorchDataConfig:
              'static_inclusion_mode': <StaticInclusionMode.INCLUDE: 'include'>,
              'task_labels_dir': None,
              'batch_mode': <BatchMode.SM: 'SM'>,
-             'include_window_end_time_in_schema': False,
+             'include_window_last_observed_in_schema': False,
              '_target_': 'meds_torchdata.config.MEDSTorchDataConfig'}
             >>> from hydra.utils import instantiate
             >>> instantiate(cfg)
@@ -180,7 +180,7 @@ class MEDSTorchDataConfig:
                                 static_inclusion_mode=<StaticInclusionMode.INCLUDE: 'include'>,
                                 task_labels_dir=None,
                                 batch_mode=<BatchMode.SM: 'SM'>,
-                                include_window_end_time_in_schema=False)
+                                include_window_last_observed_in_schema=False)
 
         Note that Hydra's CLI parameters with structured configs recognize that the `StrEnum` classes are
         enums, but fails to recognize that they accept lowercased names as the names of the class members are
@@ -216,7 +216,7 @@ class MEDSTorchDataConfig:
                                 static_inclusion_mode=<StaticInclusionMode.INCLUDE: 'include'>,
                                 task_labels_dir=None,
                                 batch_mode=<BatchMode.SM: 'SM'>,
-                                include_window_end_time_in_schema=False)
+                                include_window_last_observed_in_schema=False)
 
         You can also add the config to a group
 
@@ -231,7 +231,7 @@ class MEDSTorchDataConfig:
                              'static_inclusion_mode': <StaticInclusionMode.INCLUDE: 'include'>,
                              'task_labels_dir': None,
                              'batch_mode': <BatchMode.SM: 'SM'>,
-                             'include_window_end_time_in_schema': False,
+                             'include_window_last_observed_in_schema': False,
                              '_target_': 'meds_torchdata.config.MEDSTorchDataConfig'},
                        group='my_group/my_subgroup',
                        package=None,

--- a/src/meds_torchdata/config.py
+++ b/src/meds_torchdata/config.py
@@ -125,7 +125,7 @@ class MEDSTorchDataConfig:
     batch_mode: BatchMode = BatchMode.SM
 
     # Extra output
-    return_last_time: bool = False
+    include_window_end_time_in_schema: bool = False
 
     @classmethod
     def add_to_config_store(cls, group: str | None = None):
@@ -146,7 +146,7 @@ class MEDSTorchDataConfig:
                              'static_inclusion_mode': <StaticInclusionMode.INCLUDE: 'include'>,
                              'task_labels_dir': None,
                              'batch_mode': <BatchMode.SM: 'SM'>,
-                             'return_last_time': False,
+                             'include_window_end_time_in_schema': False,
                              '_target_': 'meds_torchdata.config.MEDSTorchDataConfig'},
                        group=None,
                        package=None,
@@ -169,7 +169,7 @@ class MEDSTorchDataConfig:
              'static_inclusion_mode': <StaticInclusionMode.INCLUDE: 'include'>,
              'task_labels_dir': None,
              'batch_mode': <BatchMode.SM: 'SM'>,
-             'return_last_time': False,
+             'include_window_end_time_in_schema': False,
              '_target_': 'meds_torchdata.config.MEDSTorchDataConfig'}
             >>> from hydra.utils import instantiate
             >>> instantiate(cfg)
@@ -180,7 +180,7 @@ class MEDSTorchDataConfig:
                                 static_inclusion_mode=<StaticInclusionMode.INCLUDE: 'include'>,
                                 task_labels_dir=None,
                                 batch_mode=<BatchMode.SM: 'SM'>,
-                                return_last_time=False)
+                                include_window_end_time_in_schema=False)
 
         Note that Hydra's CLI parameters with structured configs recognize that the `StrEnum` classes are
         enums, but fails to recognize that they accept lowercased names as the names of the class members are
@@ -216,7 +216,7 @@ class MEDSTorchDataConfig:
                                 static_inclusion_mode=<StaticInclusionMode.INCLUDE: 'include'>,
                                 task_labels_dir=None,
                                 batch_mode=<BatchMode.SM: 'SM'>,
-                                return_last_time=False)
+                                include_window_end_time_in_schema=False)
 
         You can also add the config to a group
 
@@ -231,7 +231,7 @@ class MEDSTorchDataConfig:
                              'static_inclusion_mode': <StaticInclusionMode.INCLUDE: 'include'>,
                              'task_labels_dir': None,
                              'batch_mode': <BatchMode.SM: 'SM'>,
-                             'return_last_time': False,
+                             'include_window_end_time_in_schema': False,
                              '_target_': 'meds_torchdata.config.MEDSTorchDataConfig'},
                        group='my_group/my_subgroup',
                        package=None,

--- a/src/meds_torchdata/config.py
+++ b/src/meds_torchdata/config.py
@@ -124,6 +124,9 @@ class MEDSTorchDataConfig:
     # Output Shape & Masking
     batch_mode: BatchMode = BatchMode.SM
 
+    # Extra output
+    return_last_time: bool = False
+
     @classmethod
     def add_to_config_store(cls, group: str | None = None):
         """Adds this class to the Hydra config store such that instantiation will create it natively.
@@ -143,6 +146,7 @@ class MEDSTorchDataConfig:
                              'static_inclusion_mode': <StaticInclusionMode.INCLUDE: 'include'>,
                              'task_labels_dir': None,
                              'batch_mode': <BatchMode.SM: 'SM'>,
+                             'return_last_time': False,
                              '_target_': 'meds_torchdata.config.MEDSTorchDataConfig'},
                        group=None,
                        package=None,
@@ -165,6 +169,7 @@ class MEDSTorchDataConfig:
              'static_inclusion_mode': <StaticInclusionMode.INCLUDE: 'include'>,
              'task_labels_dir': None,
              'batch_mode': <BatchMode.SM: 'SM'>,
+             'return_last_time': False,
              '_target_': 'meds_torchdata.config.MEDSTorchDataConfig'}
             >>> from hydra.utils import instantiate
             >>> instantiate(cfg)
@@ -174,7 +179,8 @@ class MEDSTorchDataConfig:
                                 padding_side=<PaddingSide.RIGHT: 'right'>,
                                 static_inclusion_mode=<StaticInclusionMode.INCLUDE: 'include'>,
                                 task_labels_dir=None,
-                                batch_mode=<BatchMode.SM: 'SM'>)
+                                batch_mode=<BatchMode.SM: 'SM'>,
+                                return_last_time=False)
 
         Note that Hydra's CLI parameters with structured configs recognize that the `StrEnum` classes are
         enums, but fails to recognize that they accept lowercased names as the names of the class members are
@@ -209,7 +215,8 @@ class MEDSTorchDataConfig:
                                 padding_side=<PaddingSide.RIGHT: 'right'>,
                                 static_inclusion_mode=<StaticInclusionMode.INCLUDE: 'include'>,
                                 task_labels_dir=None,
-                                batch_mode=<BatchMode.SM: 'SM'>)
+                                batch_mode=<BatchMode.SM: 'SM'>,
+                                return_last_time=False)
 
         You can also add the config to a group
 
@@ -224,6 +231,7 @@ class MEDSTorchDataConfig:
                              'static_inclusion_mode': <StaticInclusionMode.INCLUDE: 'include'>,
                              'task_labels_dir': None,
                              'batch_mode': <BatchMode.SM: 'SM'>,
+                             'return_last_time': False,
                              '_target_': 'meds_torchdata.config.MEDSTorchDataConfig'},
                        group='my_group/my_subgroup',
                        package=None,

--- a/src/meds_torchdata/pytorch_dataset.py
+++ b/src/meds_torchdata/pytorch_dataset.py
@@ -70,7 +70,7 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
 
     LABEL_COL = LabelSchema.boolean_value_name
     END_IDX = "end_event_index"
-    LAST_TIME = "window_end_time"
+    LAST_TIME = "window_last_observed"
 
     @classmethod
     def get_task_seq_bounds_and_labels(cls, label_df: pl.DataFrame, schema_df: pl.DataFrame) -> pl.DataFrame:
@@ -326,13 +326,7 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
             └────────────┴─────────────────┴─────────────────────┘
         """
 
-        base_df = pl.concat(
-            (
-                df.select(DataSchema.subject_id_name, DataSchema.time_name)
-                for df in self.schema_dfs_by_shard.values()
-            ),
-            how="vertical",
-        )
+        base_df = self._all_schemas
 
         if self.has_task_index:
             df = self.get_task_seq_bounds_and_labels(self.labels_df, base_df)
@@ -342,19 +336,34 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
             )
 
         if (
-            self.config.include_window_end_time_in_schema
+            self.config.include_window_last_observed_in_schema
             and self.has_task_index
             and self.config.seq_sampling_strategy != SubsequenceSamplingStrategy.RANDOM
         ):
             df = (
                 df.join(base_df, on=DataSchema.subject_id_name, how="left", maintain_order="left")
                 .with_columns(
-                    pl.col(DataSchema.time_name).list.get(pl.col(self.END_IDX) - 1).alias(self.LAST_TIME)
+                    pl.from_epoch(  # This is a polars error where the timestamp was converted to ints...
+                        pl.col(DataSchema.time_name).list.get(pl.col(self.END_IDX) - 1),
+                        time_unit="us",
+                    ).alias(self.LAST_TIME)
                 )
                 .drop(DataSchema.time_name)
             )
 
         return df
+
+    @property
+    def _all_schemas(self) -> pl.DataFrame:
+        """This is a helper for easy access to the full set of schema dataframes for debugging."""
+
+        return pl.concat(
+            (
+                df.select(DataSchema.subject_id_name, DataSchema.time_name)
+                for df in self.schema_dfs_by_shard.values()
+            ),
+            how="vertical",
+        )
 
     def __len__(self):
         """Returns the length of the dataset.

--- a/src/meds_torchdata/pytorch_dataset.py
+++ b/src/meds_torchdata/pytorch_dataset.py
@@ -324,7 +324,6 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
             │ 814703     ┆ 2               ┆ 2010-02-05 06:30:00 │
             │ 814703     ┆ 2               ┆ 2010-02-05 07:00:00 │
             └────────────┴─────────────────┴─────────────────────┘
-
         """
 
         base_df = pl.concat(
@@ -350,9 +349,7 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
             df = (
                 df.join(base_df, on=DataSchema.subject_id_name, how="left", maintain_order="left")
                 .with_columns(
-                    pl.col(DataSchema.time_name)
-                    .list.get(pl.col(self.END_IDX) - 1)
-                    .alias(self.LAST_TIME)
+                    pl.col(DataSchema.time_name).list.get(pl.col(self.END_IDX) - 1).alias(self.LAST_TIME)
                 )
                 .drop(DataSchema.time_name)
             )

--- a/src/meds_torchdata/pytorch_dataset.py
+++ b/src/meds_torchdata/pytorch_dataset.py
@@ -342,7 +342,7 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
             )
 
         if (
-            self.config.return_last_time
+            self.config.include_window_end_time_in_schema
             and self.has_task_index
             and self.config.seq_sampling_strategy != SubsequenceSamplingStrategy.RANDOM
         ):

--- a/tests/test_pytorch_dataset.py
+++ b/tests/test_pytorch_dataset.py
@@ -29,7 +29,7 @@ def test_schema_df_last_time(tensorized_MEDS_dataset_with_index):
         task_labels_dir=(tasks_dir / task_name),
         max_seq_len=10,
         seq_sampling_strategy="to_end",
-        return_last_time=True,
+        include_window_end_time_in_schema=True,
     )
 
     pyd = MEDSPytorchDataset(cfg, split="train")

--- a/tests/test_pytorch_dataset.py
+++ b/tests/test_pytorch_dataset.py
@@ -1,5 +1,6 @@
-from meds_torchdata import MEDSPytorchDataset, MEDSTorchBatch, MEDSTorchDataConfig
 from meds import DataSchema
+
+from meds_torchdata import MEDSPytorchDataset, MEDSTorchBatch, MEDSTorchDataConfig
 
 
 def test_dataset(sample_pytorch_dataset: MEDSPytorchDataset):

--- a/tests/test_pytorch_dataset.py
+++ b/tests/test_pytorch_dataset.py
@@ -1,4 +1,5 @@
-from meds_torchdata import MEDSPytorchDataset, MEDSTorchBatch
+from meds_torchdata import MEDSPytorchDataset, MEDSTorchBatch, MEDSTorchDataConfig
+from meds import DataSchema
 
 
 def test_dataset(sample_pytorch_dataset: MEDSPytorchDataset):
@@ -18,6 +19,27 @@ def test_dataset(sample_pytorch_dataset: MEDSPytorchDataset):
     dataloader = pyd.get_dataloader(batch_size=32, num_workers=2)
     batch = next(iter(dataloader))
     assert isinstance(batch, MEDSTorchBatch)
+
+
+def test_schema_df_last_time(tensorized_MEDS_dataset_with_index):
+    cohort_dir, tasks_dir, task_name = tensorized_MEDS_dataset_with_index
+    cfg = MEDSTorchDataConfig(
+        tensorized_cohort_dir=cohort_dir,
+        task_labels_dir=(tasks_dir / task_name),
+        max_seq_len=10,
+        seq_sampling_strategy="to_end",
+        return_last_time=True,
+    )
+
+    pyd = MEDSPytorchDataset(cfg, split="train")
+    assert MEDSPytorchDataset.LAST_TIME in pyd.schema_df.columns
+
+    subj, end_idx = pyd.index[0]
+    shard, subj_idx = pyd.subj_locations[subj]
+    times = pyd.schema_dfs_by_shard[shard][DataSchema.time_name][subj_idx]
+    expected = times[end_idx - 1]
+    expected_ts = int(expected.timestamp() * 1_000_000)
+    assert pyd.schema_df[pyd.LAST_TIME][0] == expected_ts
 
 
 def test_dataset_with_task(sample_pytorch_dataset_with_task: MEDSPytorchDataset):

--- a/tests/test_pytorch_dataset.py
+++ b/tests/test_pytorch_dataset.py
@@ -29,7 +29,7 @@ def test_schema_df_last_time(tensorized_MEDS_dataset_with_index):
         task_labels_dir=(tasks_dir / task_name),
         max_seq_len=10,
         seq_sampling_strategy="to_end",
-        include_window_end_time_in_schema=True,
+        include_window_last_observed_in_schema=True,
     )
 
     pyd = MEDSPytorchDataset(cfg, split="train")
@@ -38,9 +38,7 @@ def test_schema_df_last_time(tensorized_MEDS_dataset_with_index):
     subj, end_idx = pyd.index[0]
     shard, subj_idx = pyd.subj_locations[subj]
     times = pyd.schema_dfs_by_shard[shard][DataSchema.time_name][subj_idx]
-    expected = times[end_idx - 1]
-    expected_ts = int(expected.timestamp() * 1_000_000)
-    assert pyd.schema_df[pyd.LAST_TIME][0] == expected_ts
+    assert pyd.schema_df[pyd.LAST_TIME][0] == times[end_idx - 1]
 
 
 def test_dataset_with_task(sample_pytorch_dataset_with_task: MEDSPytorchDataset):


### PR DESCRIPTION
Closes #52

## Summary
- allow exposing the last observed timestamp via `return_last_time`
- document new option in README
- include window end time when building schema dataframe
- test behaviour for indexed datasets

## Testing
- `pytest -q -m "not parallelized and not lightning" --ignore=benchmark --ignore=src/meds_torchdata/extensions`

------
https://chatgpt.com/codex/tasks/task_e_6840b29eb3a0832ca9102d850a4c70a2