### PR TITLE
CI bumps, pre-commit pins, dep broadening + two small bugfixes (#63, #67)

### DIFF
--- a/.github/workflows/code-quality-pr.yaml
+++ b/.github/workflows/code-quality-pr.yaml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Find modified files
         id: file_changes
-        uses: tj-actions/changed-files@v46.0.5
+        uses: tj-actions/changed-files@v47.0.5
 
       - name: List all changed files
         run: echo '${{ steps.file_changes.outputs.all_changed_files }}'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,6 +11,8 @@ jobs:
 
     strategy:
       fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
 
     timeout-minutes: 30
 
@@ -20,7 +22,7 @@ jobs:
       - name: Setup package
         uses: ./.github/actions/setup
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
 
       - name: Run tests
         run: >
@@ -28,7 +30,7 @@ jobs:
           --ignore="benchmark" --ignore="src/meds_torchdata/extensions"
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@v5.5.4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -41,7 +43,7 @@ jobs:
           uv run pytest -v --cov=src src/meds_torchdata/extensions/lightning_datamodule.py
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@v5.5.4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -50,7 +52,7 @@ jobs:
           uv run pytest -v --cov=src tests/ -m "lightning and not parallelized"
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@v5.5.4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -63,6 +65,6 @@ jobs:
           uv run pytest -v --cov=src tests/ -m "parallelized and not lightning"
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@v5.5.4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       # list of supported hooks: https://pre-commit.com/hooks.html
       - id: trailing-whitespace
@@ -14,23 +14,25 @@ repos:
       - id: detect-private-key
       - id: check-executables-have-shebangs
       - id: check-toml
+      - id: check-json
+      - id: check-merge-conflict
       - id: check-case-conflict
       - id: check-added-large-files
         args: [--maxkb, "800"]
 
   # python code formatting, linting, and import sorting using ruff
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.5
+    rev: v0.15.10
     hooks:
       # Run the formatter
       - id: ruff-format
       # Run the linter
-      - id: ruff
+      - id: ruff-check
         args: ["--fix", "--exit-non-zero-on-fix"]
 
   # python docstring formatting
-  - repo: https://github.com/myint/docformatter
-    rev: v1.7.5
+  - repo: https://github.com/PyCQA/docformatter
+    rev: v1.7.7
     hooks:
       - id: docformatter
         args: [--in-place, --wrap-summaries=110, --wrap-descriptions=110]
@@ -45,31 +47,34 @@ repos:
 
   # shell scripts linter
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.10.0.1
+    rev: v0.11.0.1
     hooks:
       - id: shellcheck
 
   # md formatting
+  # NOTE: additional_dependencies are pinned to exact versions to reduce CI flakiness
+  # caused by upstream plugin releases that are incompatible with the mdformat rev
+  # below. When bumping mdformat, verify each plugin version is still compatible.
   - repo: https://github.com/executablebooks/mdformat
     rev: 0.7.22
     hooks:
       - id: mdformat
         args: ["--number"]
         additional_dependencies:
-          - mdformat-ruff
-          - mdformat-gfm
-          - mdformat-gfm-alerts
-          - mdformat-tables
-          - mdformat_frontmatter
-          - mdformat-black
-          - mdformat-config
-          - mdformat-shfmt
-          - mdformat-mkdocs
-          - mdformat-toc
+          - mdformat-ruff==0.1.3
+          - mdformat-gfm==1.0.0
+          - mdformat-gfm-alerts==2.0.0
+          - mdformat-tables==1.0.0
+          - mdformat_frontmatter==2.0.10
+          - mdformat-black==0.1.1
+          - mdformat-config==0.2.1
+          - mdformat-shfmt==0.2.0
+          - mdformat-mkdocs==5.1.4
+          - mdformat-toc==0.5.0
 
   # word spelling linter
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+    rev: v2.4.2
     hooks:
       - id: codespell
         args:
@@ -78,7 +83,7 @@ repos:
 
   # jupyter notebook cell output clearing
   - repo: https://github.com/kynan/nbstripout
-    rev: 0.8.1
+    rev: 0.9.1
     hooks:
       - id: nbstripout
 

--- a/README.md
+++ b/README.md
@@ -531,13 +531,13 @@ n_static_seq_els (int):
 2
 dynamic (JointNestedRaggedTensorDict):
 code
-[ 8  9  3 10 11]
+[ 8  9 10 11  4]
 .
 numeric_value
-[        nan -0.54382396         nan -1.4474752  -0.34049404]
+[        nan -0.54382396 -1.4474752  -0.34049404         nan]
 .
 time_delta_days
-[       nan        nan 11766.1045     0.         0.    ]
+[       nan        nan 0.         0.         0.09787037]
 >>> pyd.config.static_inclusion_mode = "include"
 
 ```
@@ -603,13 +603,13 @@ static_numeric_value (list):
 [nan, 0.06802856922149658]
 dynamic (JointNestedRaggedTensorDict):
 code
-[10 11 10 11 10]
+[11 10 11 10 11]
 .
 numeric_value
-[-0.04626633  0.69391906 -0.30007038  0.79735875 -0.31064537]
+[ 0.69391906 -0.30007038  0.79735875 -0.31064537  1.0042422 ]
 .
 time_delta_days
-[0.01888889 0.         0.0084838  0.         0.01167824]
+[0.         0.0084838  0.         0.01167824 0.        ]
 >>> print_element(pyd._seeded_getitem(1, seed=1))
 static_code (list):
 [6, 9]
@@ -617,13 +617,13 @@ static_numeric_value (list):
 [nan, 0.06802856922149658]
 dynamic (JointNestedRaggedTensorDict):
 code
-[10 11 10 11 10]
+[11 10 11 10 11]
 .
 numeric_value
-[ 0.03833488  0.79735875  0.33972722  0.7456389  -0.04626633]
+[ 0.79735875  0.33972722  0.7456389  -0.04626633  0.69391906]
 .
 time_delta_days
-[0.00115741 0.         0.01373843 0.         0.01888889]
+[0.         0.01373843 0.         0.01888889 0.        ]
 
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,20 +20,20 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "pytest",
-    "polars~=1.30.0",
-    "nested_ragged_tensors>=0.1.0",
-    "numpy",
-    "torch",
-    "meds~=0.4.0",
-    "MEDS_transforms~=0.5.2",
-    "hydra-core",
-    "omegaconf",
-    "meds_testing_helpers>=0.3.0"
+    "pytest",  # re-exported as a pytest plugin via `[project.entry-points.pytest11]`
+    "polars>=1.30,<2",
+    "nested_ragged_tensors>=0.1.0,<0.2",
+    "numpy>=1.26,<3",
+    "torch>=2.0",
+    "meds>=0.4,<0.5",
+    "MEDS_transforms>=0.5.2,<0.6",
+    "hydra-core>=1.3",
+    "omegaconf>=2.3",
+    "meds_testing_helpers>=0.3,<0.4",
 ]
 
 [dependency-groups]
-dev = ["pre-commit<4", "ruff", "pytest-cov", "hypothesis"]
+dev = ["pre-commit", "ruff", "pytest-cov", "hypothesis"]
 benchmarks = ["ml-mixins[memtrackable]>=0.2", "rootutils"]
 docs = [
   "mkdocs==1.6.1", "mkdocs-material==9.6.7", "mkdocstrings[python]==0.28.2", "mkdocstrings-shell~=1.0",

--- a/src/meds_torchdata/config.py
+++ b/src/meds_torchdata/config.py
@@ -550,10 +550,10 @@ class MEDSTorchDataConfig:
             [4 5 0]
             >>> pprint_dense(cfg.process_dynamic_data(data, rng=3).to_dense())
             code
-            [52 60 70]
+            [60 70 71]
             .
             time_delta
-            [0 6 7]
+            [6 7 0]
 
         If we pass in an invalid number of static sequence elements to reserve, we get an error.
 

--- a/src/meds_torchdata/preprocessing/tokenization.py
+++ b/src/meds_torchdata/preprocessing/tokenization.py
@@ -266,7 +266,7 @@ def main(cfg: DictConfig):
     output_dir = Path(cfg.stage_cfg.output_dir)
     if train_only := cfg.stage_cfg.get("train_only", False):
         raise ValueError(f"train_only={train_only} is not supported for this stage.")
-    shards_single_output, include_only_train = shard_iterator(cfg)
+    shards_single_output, _ = shard_iterator(cfg)
 
     for in_fp, out_fp in shards_single_output:
         sharded_path = out_fp.relative_to(output_dir)

--- a/src/meds_torchdata/pytorch_dataset.py
+++ b/src/meds_torchdata/pytorch_dataset.py
@@ -587,8 +587,15 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
         subject_dynamic_data = JointNestedRaggedTensorDict(tensors_fp=dynamic_data_fp)[subject_idx, st:end]
 
         subj_schema = self.schema_dfs_by_shard[shard][subject_idx]
-        static_code = subj_schema["static_code"].item().to_list()
-        static_numeric_value = subj_schema["static_numeric_value"].item().to_list()
+        # `.item()` returns the polars list for a given row. When the dataset has no static
+        # data at all, the column may be null (not just an empty list), in which case `.item()`
+        # returns `None` and `.to_list()` would raise `AttributeError`. See issue #63.
+        static_code_list = subj_schema["static_code"].item()
+        static_numeric_value_list = subj_schema["static_numeric_value"].item()
+        static_code = static_code_list.to_list() if static_code_list is not None else []
+        static_numeric_value = (
+            static_numeric_value_list.to_list() if static_numeric_value_list is not None else []
+        )
 
         return subject_dynamic_data, StaticData(static_code, static_numeric_value)
 

--- a/src/meds_torchdata/types.py
+++ b/src/meds_torchdata/types.py
@@ -75,6 +75,19 @@ class SubsequenceSamplingStrategy(StrEnum):
             2
             >>> SubsequenceSamplingStrategy.RANDOM.subsample_st_offset(10, 10) is None
             True
+
+            The random sampler must be able to place the window flush against the end of the
+            sequence (i.e. sample `st = seq_len - max_seq_len`, so that the last event at index
+            `seq_len - 1` is included). Prior to the fix for issue #67 this was off-by-one and
+            the last event was never reachable:
+
+            >>> possible_st = {
+            ...     SubsequenceSamplingStrategy.subsample_st_offset("random", 10, 5, rng=s)
+            ...     for s in range(1000)
+            ... }
+            >>> sorted(possible_st)
+            [0, 1, 2, 3, 4, 5]
+
             >>> SubsequenceSamplingStrategy.subsample_st_offset("foo", 10, 5)
             Traceback (most recent call last):
                 ...
@@ -86,7 +99,10 @@ class SubsequenceSamplingStrategy(StrEnum):
 
         match self:
             case SubsequenceSamplingStrategy.RANDOM:
-                return resolve_rng(rng).choice(seq_len - max_seq_len)
+                # NOTE: `choice(n)` draws from `[0, n)`, so to let `st` reach `seq_len - max_seq_len`
+                # (and thus let `data[st:st + max_seq_len]` include the final event at index
+                # `seq_len - 1`) we must pass `seq_len - max_seq_len + 1`. See issue #67.
+                return resolve_rng(rng).choice(seq_len - max_seq_len + 1)
             case SubsequenceSamplingStrategy.TO_END:
                 return seq_len - max_seq_len
             case SubsequenceSamplingStrategy.FROM_START:

--- a/tests/test_pytorch_dataset_properties.py
+++ b/tests/test_pytorch_dataset_properties.py
@@ -65,7 +65,7 @@ def test_get_task_seq_bounds_and_labels_property(data):
 
     # Drop labels for subjects not in schema_df
     label_subset = label_df.filter(
-        pl.col(DataSchema.subject_id_name).is_in(schema_df[DataSchema.subject_id_name])
+        pl.col(DataSchema.subject_id_name).is_in(schema_df[DataSchema.subject_id_name].implode())
     )
 
     expected_rows = []

--- a/uv.lock
+++ b/uv.lock
@@ -841,18 +841,18 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "hydra-core" },
+    { name = "hydra-core", specifier = ">=1.3" },
     { name = "hydra-joblib-launcher", marker = "extra == 'parallelized'", specifier = "~=1.2.0" },
     { name = "lightning", marker = "extra == 'lightning'", specifier = "~=2.5.1" },
-    { name = "meds", specifier = "~=0.4.0" },
-    { name = "meds-testing-helpers", specifier = ">=0.3.0" },
-    { name = "meds-transforms", specifier = "~=0.5.2" },
-    { name = "nested-ragged-tensors", specifier = ">=0.1.0" },
-    { name = "numpy" },
-    { name = "omegaconf" },
-    { name = "polars", specifier = "~=1.30.0" },
+    { name = "meds", specifier = ">=0.4,<0.5" },
+    { name = "meds-testing-helpers", specifier = ">=0.3,<0.4" },
+    { name = "meds-transforms", specifier = ">=0.5.2,<0.6" },
+    { name = "nested-ragged-tensors", specifier = ">=0.1.0,<0.2" },
+    { name = "numpy", specifier = ">=1.26,<3" },
+    { name = "omegaconf", specifier = ">=2.3" },
+    { name = "polars", specifier = ">=1.30,<2" },
     { name = "pytest" },
-    { name = "torch" },
+    { name = "torch", specifier = ">=2.0" },
 ]
 provides-extras = ["parallelized", "lightning"]
 
@@ -863,7 +863,7 @@ benchmarks = [
 ]
 dev = [
     { name = "hypothesis" },
-    { name = "pre-commit", specifier = "<4" },
+    { name = "pre-commit" },
     { name = "pytest-cov" },
     { name = "ruff" },
 ]


### PR DESCRIPTION
## Summary

A grab-bag of low-risk housekeeping + two small bugfixes surfaced along the way.

**CI / pre-commit**
- `codecov-action` v4.0.1 → v5.5.4 (v4 is EOL; v6 introduces node24 requirement so we stay on v5.5.4)
- `tj-actions/changed-files` v46.0.5 → v47.0.5
- Test matrix now runs on Python 3.11 and 3.12 (3.11 is the project minimum; previously only 3.12 was exercised)
- Pre-commit hook revs bumped (`pre-commit-hooks` v6, `ruff-pre-commit` v0.15.10, `docformatter` v1.7.7, `shellcheck-py` v0.11.0.1, `codespell` v2.4.2, `nbstripout` 0.9.1)
- `mdformat` `additional_dependencies` are now pinned to exact versions to stop CI from flaking every time an unrelated mdformat plugin cuts a release
- Switched the ruff linter hook to the non-deprecated `ruff-check` id

**Dependencies (`pyproject.toml`)**
- Broadened direct specifiers so downstream users aren't locked into narrow ranges:
  - `polars ~=1.30.0` → `polars>=1.30,<2`
  - `meds ~=0.4.0` → `meds>=0.4,<0.5`
  - `MEDS_transforms ~=0.5.2` → `>=0.5.2,<0.6` (the 0.6 upgrade is its own effort — tracked in #57)
  - `nested_ragged_tensors>=0.1.0` → `>=0.1.0,<0.2`
  - Added sane floors for `numpy`, `torch`, `hydra-core`, `omegaconf`
  - Dropped the `pre-commit<4` dev pin
- `uv.lock` is intentionally left at the known-good resolution (the widened specifiers only affect *new* installs). I tried `uv lock --upgrade` but the newer meds/MEDS_transforms/meds_testing_helpers combination shifts tokenizer vocabulary indices by one across every doctest, which is unrelated to this PR — better handled when #57 (MEDS-Transforms 0.6) is addressed.

**Bugfixes**
1. **`types.py`: off-by-one in RANDOM subsequence sampling.** `rng.choice(n)` returns an integer in `[0, n)`, so `choice(seq_len - max_seq_len)` could never let `st` reach `seq_len - max_seq_len`, and the final event at index `seq_len - 1` was *never* included in any random training window. This is the bug described in #67, which also covers a deeper structural bias that this PR does not fix. A doctest was added asserting that `st = seq_len - max_seq_len` is reachable.
2. **`pytorch_dataset.py`: null static data.** When a dataset has no static data at all, `subj_schema["static_code"].item()` returns `None` and `.to_list()` blew up. Now guarded. Closes #63.

**Hygiene**
- `preprocessing/tokenization.py`: drop the unused tuple element from `shard_iterator(cfg)` (RUF059, surfaced by ruff 0.15)
- `tests/test_pytorch_dataset_properties.py`: use `.implode()` for `Expr.is_in(Series)` to silence the polars 1.30 deprecation warning about `is_in` with a collection of the same datatype

## Test plan
- [x] `uv run pytest -q` (base markers): 47 passed, 2 skipped
- [x] `uv run pytest` with the `lightning` extra: extension doctest + 3 lightning tests pass
- [x] `uv run pytest` with the `parallelized` extra: 1 passed
- [x] `uv run pre-commit run --all-files`: all hooks green
- [ ] CI on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)