### PR TITLE
Add STEP_THROUGH subsequence sampling strategy

### DIFF
--- a/src/meds_torchdata/config.py
+++ b/src/meds_torchdata/config.py
@@ -105,6 +105,48 @@ class MEDSTorchDataConfig:
         Traceback (most recent call last):
             ...
         ValueError: Invalid static inclusion mode: foobar
+
+        STEP_THROUGH sampling requires a positive integer ``step_through_stride``. A missing,
+        zero, negative, or non-int stride raises. ``bool`` is explicitly rejected because it is
+        a subclass of ``int`` in Python (so ``isinstance(True, int)`` would otherwise silently
+        accept it as stride 1):
+
+        >>> MEDSTorchDataConfig(
+        ...     tensorized_cohort_dir=".", max_seq_len=3, seq_sampling_strategy="step_through"
+        ... )
+        Traceback (most recent call last):
+            ...
+        ValueError: step_through_stride must be a positive integer when seq_sampling_strategy is
+        STEP_THROUGH; got None.
+        >>> MEDSTorchDataConfig(
+        ...     tensorized_cohort_dir=".", max_seq_len=3, seq_sampling_strategy="step_through",
+        ...     step_through_stride=0,
+        ... )
+        Traceback (most recent call last):
+            ...
+        ValueError: step_through_stride must be a positive integer when seq_sampling_strategy is
+        STEP_THROUGH; got 0.
+        >>> MEDSTorchDataConfig(
+        ...     tensorized_cohort_dir=".", max_seq_len=3, seq_sampling_strategy="step_through",
+        ...     step_through_stride=True,
+        ... )
+        Traceback (most recent call last):
+            ...
+        ValueError: step_through_stride must be a positive integer when seq_sampling_strategy is
+        STEP_THROUGH; got True.
+
+        Conversely, setting ``step_through_stride`` with any other strategy is also rejected,
+        because the field has no effect outside STEP_THROUGH and silently accepting it would
+        mask configuration mistakes:
+
+        >>> MEDSTorchDataConfig(
+        ...     tensorized_cohort_dir=".", max_seq_len=3, seq_sampling_strategy="random",
+        ...     step_through_stride=2,
+        ... )
+        Traceback (most recent call last):
+            ...
+        ValueError: step_through_stride may only be set when seq_sampling_strategy is STEP_THROUGH;
+        got strategy random with stride 2.
     """
 
     # MEDS Dataset Information
@@ -439,7 +481,6 @@ class MEDSTorchDataConfig:
         data: JointNestedRaggedTensorDict,
         n_static_seq_els: int | None = None,
         rng: np.random.Generator | int | None = None,
-        explicit_window: tuple[int, int] | None = None,
     ) -> JointNestedRaggedTensorDict:
         """This processes the dynamic data for a subject, including subsampling and flattening.
 
@@ -450,17 +491,6 @@ class MEDSTorchDataConfig:
                 `None`.
             rng: The random seed to use for subsequence sampling. If `None`, the default rng is used. If an
                 integer, a new rng is created with that seed.
-            explicit_window: An optional pre-computed `(st, end)` slice in the units used by the
-                sampling strategies — that is, events in `BatchMode.SEM` and post-flatten
-                measurements in `BatchMode.SM`. When provided, `process_dynamic_data` honors this
-                slice directly instead of asking the strategy's `subsample_st_offset` for a
-                random start, so it bypasses the RNG entirely. This is used by
-                `STEP_THROUGH` sampling, where `MEDSPytorchDataset` pre-computes one window per
-                dataset element at init time. The provided `end` is still clamped against the
-                effective maximum — `min(seq_len, end, st + max_seq_len)` with `max_seq_len`
-                already reduced by `n_static_seq_els` in `PREPEND` mode — so the concatenated
-                `[static; dynamic]` sample can never exceed `config.max_seq_len` even if the
-                caller passes an oversized window.
 
         Returns:
             The processed dynamic data, still in a `JointNestedRaggedTensorDict` format.
@@ -668,26 +698,15 @@ class MEDSTorchDataConfig:
 
             max_seq_len -= n_static_seq_els
 
-        if explicit_window is not None:
-            # STEP_THROUGH hands us a pre-computed `(st, end)` window from the dataset-level
-            # expansion — honor it directly rather than asking the (non-deterministic) sampler,
-            # but still enforce the effective max sequence length (post `-= n_static_seq_els`
-            # reduction above) so PREPEND concatenation can never produce a sample longer than
-            # `config.max_seq_len`.
-            st, end = explicit_window
-            st = max(0, st)
-            end = min(seq_len, end, st + max_seq_len)
-            return data[st:end]
-
         st = self.seq_sampling_strategy.subsample_st_offset(seq_len, max_seq_len, rng=rng)
-
         if st is None:
             st = 0
+        end = st + max_seq_len
 
-        end = min(seq_len, st + max_seq_len)
-        # `BALANCED_RANDOM` may return a negative start offset to let windows overhang the left
-        # boundary (yielding a uniform per-event inclusion distribution). Clamp the actual slice
-        # start to zero so we just return the (shorter) in-sequence portion; padding is handled
-        # by the collator downstream.
+        # Clamp the resulting slice: `BALANCED_RANDOM` can return a negative `st` so the
+        # window overhangs the left boundary (yielding a uniform per-event inclusion
+        # distribution — padding is handled by the collator downstream); `end` likewise may
+        # overhang the right boundary or exceed `seq_len` for short sequences.
         st = max(0, st)
+        end = min(seq_len, end)
         return data[st:end]

--- a/src/meds_torchdata/config.py
+++ b/src/meds_torchdata/config.py
@@ -312,7 +312,14 @@ class MEDSTorchDataConfig:
                 )
 
         if self.seq_sampling_strategy == SubsequenceSamplingStrategy.STEP_THROUGH:
-            if not isinstance(self.step_through_stride, int) or self.step_through_stride <= 0:
+            # `bool` is a subclass of `int`, so `isinstance(True, int)` is `True`. Reject
+            # `bool` explicitly so `step_through_stride=True` doesn't silently behave like
+            # stride 1.
+            if (
+                isinstance(self.step_through_stride, bool)
+                or not isinstance(self.step_through_stride, int)
+                or self.step_through_stride <= 0
+            ):
                 raise ValueError(
                     "step_through_stride must be a positive integer when seq_sampling_strategy is "
                     f"STEP_THROUGH; got {self.step_through_stride!r}."

--- a/src/meds_torchdata/config.py
+++ b/src/meds_torchdata/config.py
@@ -618,10 +618,13 @@ class MEDSTorchDataConfig:
 
         if explicit_window is not None:
             # STEP_THROUGH hands us a pre-computed `(st, end)` window from the dataset-level
-            # expansion — honor it directly rather than asking the (non-deterministic) sampler.
+            # expansion — honor it directly rather than asking the (non-deterministic) sampler,
+            # but still enforce the effective max sequence length (post `-= n_static_seq_els`
+            # reduction above) so PREPEND concatenation can never produce a sample longer than
+            # `config.max_seq_len`.
             st, end = explicit_window
             st = max(0, st)
-            end = min(seq_len, end)
+            end = min(seq_len, end, st + max_seq_len)
             return data[st:end]
 
         st = self.seq_sampling_strategy.subsample_st_offset(seq_len, max_seq_len, rng=rng)

--- a/src/meds_torchdata/config.py
+++ b/src/meds_torchdata/config.py
@@ -106,18 +106,33 @@ class MEDSTorchDataConfig:
             ...
         ValueError: Invalid static inclusion mode: foobar
 
-        STEP_THROUGH sampling requires a positive integer ``step_through_stride``. A missing,
-        zero, negative, or non-int stride raises. ``bool`` is explicitly rejected because it is
-        a subclass of ``int`` in Python (so ``isinstance(True, int)`` would otherwise silently
-        accept it as stride 1):
+        STEP_THROUGH sampling requires exactly one of ``step_through_stride`` (elements to
+        advance between consecutive windows) or ``step_through_overlap`` (elements consecutive
+        windows should share). Both are in the same unit as ``max_seq_len`` — events in SEM
+        mode, measurements in SM mode. Leaving both unset, or setting both, raises:
 
         >>> MEDSTorchDataConfig(
         ...     tensorized_cohort_dir=".", max_seq_len=3, seq_sampling_strategy="step_through"
         ... )
         Traceback (most recent call last):
             ...
-        ValueError: step_through_stride must be a positive integer when seq_sampling_strategy is
-        STEP_THROUGH; got None.
+        ValueError: Exactly one of step_through_stride or step_through_overlap must be set when
+        seq_sampling_strategy is STEP_THROUGH; got step_through_stride=None,
+        step_through_overlap=None.
+        >>> MEDSTorchDataConfig(
+        ...     tensorized_cohort_dir=".", max_seq_len=3, seq_sampling_strategy="step_through",
+        ...     step_through_stride=2, step_through_overlap=1,
+        ... )
+        Traceback (most recent call last):
+            ...
+        ValueError: Exactly one of step_through_stride or step_through_overlap must be set when
+        seq_sampling_strategy is STEP_THROUGH; got step_through_stride=2,
+        step_through_overlap=1.
+
+        ``step_through_stride`` must be a positive integer. Zero / negative / non-int values
+        are rejected, and ``bool`` is explicitly rejected because it is a subclass of ``int``
+        in Python (so ``isinstance(True, int)`` would otherwise silently accept it as stride 1):
+
         >>> MEDSTorchDataConfig(
         ...     tensorized_cohort_dir=".", max_seq_len=3, seq_sampling_strategy="step_through",
         ...     step_through_stride=0,
@@ -135,9 +150,29 @@ class MEDSTorchDataConfig:
         ValueError: step_through_stride must be a positive integer when seq_sampling_strategy is
         STEP_THROUGH; got True.
 
-        Conversely, setting ``step_through_stride`` with any other strategy is also rejected,
-        because the field has no effect outside STEP_THROUGH and silently accepting it would
-        mask configuration mistakes:
+        ``step_through_overlap`` must be a non-negative integer (``0`` = contiguous
+        non-overlapping windows). ``bool`` is again explicitly rejected:
+
+        >>> MEDSTorchDataConfig(
+        ...     tensorized_cohort_dir=".", max_seq_len=3, seq_sampling_strategy="step_through",
+        ...     step_through_overlap=-1,
+        ... )
+        Traceback (most recent call last):
+            ...
+        ValueError: step_through_overlap must be a non-negative integer when seq_sampling_strategy
+        is STEP_THROUGH; got -1.
+        >>> MEDSTorchDataConfig(
+        ...     tensorized_cohort_dir=".", max_seq_len=3, seq_sampling_strategy="step_through",
+        ...     step_through_overlap=True,
+        ... )
+        Traceback (most recent call last):
+            ...
+        ValueError: step_through_overlap must be a non-negative integer when seq_sampling_strategy
+        is STEP_THROUGH; got True.
+
+        Conversely, setting ``step_through_stride`` or ``step_through_overlap`` with any other
+        strategy is also rejected, because the fields have no effect outside STEP_THROUGH and
+        silently accepting them would mask configuration mistakes:
 
         >>> MEDSTorchDataConfig(
         ...     tensorized_cohort_dir=".", max_seq_len=3, seq_sampling_strategy="random",
@@ -147,6 +182,14 @@ class MEDSTorchDataConfig:
             ...
         ValueError: step_through_stride may only be set when seq_sampling_strategy is STEP_THROUGH;
         got strategy random with stride 2.
+        >>> MEDSTorchDataConfig(
+        ...     tensorized_cohort_dir=".", max_seq_len=3, seq_sampling_strategy="random",
+        ...     step_through_overlap=0,
+        ... )
+        Traceback (most recent call last):
+            ...
+        ValueError: step_through_overlap may only be set when seq_sampling_strategy is STEP_THROUGH;
+        got strategy random with overlap 0.
     """
 
     # MEDS Dataset Information
@@ -169,15 +212,26 @@ class MEDSTorchDataConfig:
     # Extra output
     include_window_last_observed_in_schema: bool = False
 
-    # STEP_THROUGH sampling-specific options.
-    # - `step_through_stride`: stride (in sequence elements, matching the units of `max_seq_len`)
-    #   between consecutive windows. Must be a positive integer when `seq_sampling_strategy ==
-    #   STEP_THROUGH`. Must be `None` for all other strategies.
+    # STEP_THROUGH sampling-specific options. Exactly one of `step_through_stride` or
+    # `step_through_overlap` must be set when `seq_sampling_strategy == STEP_THROUGH`; both
+    # must be `None` for all other strategies. Both are specified in the same unit as
+    # `max_seq_len` — events in SEM mode, measurements in SM mode.
+    #
+    # - `step_through_stride`: the number of sequence elements to advance between consecutive
+    #   windows. Must be a positive integer `<=` the effective window width (otherwise some
+    #   elements would be skipped between windows); validated at dataset construction time
+    #   because the effective window can vary per subject in SM+PREPEND mode.
+    # - `step_through_overlap`: the number of sequence elements consecutive windows should
+    #   share. Equivalent to `stride = effective_window - overlap`, but more convenient when
+    #   the user wants "no overlap" (`overlap=0`) or "overlap by N" without having to think
+    #   about the effective window. Must be a non-negative integer strictly less than the
+    #   effective window.
     # - `include_subject_window_counts_in_batch`: when True, the collated `MEDSTorchBatch` will
     #   populate its `n_subject_windows` tensor (shape `[batch_size]`) with the number of
     #   dataset elements each sample's subject expands into, so downstream losses can reweight
     #   by `1 / n_subject_windows` to undo step-through oversampling of long sequences.
     step_through_stride: int | None = None
+    step_through_overlap: int | None = None
     include_subject_window_counts_in_batch: bool = False
 
     @classmethod
@@ -201,6 +255,7 @@ class MEDSTorchDataConfig:
                              'batch_mode': <BatchMode.SM: 'SM'>,
                              'include_window_last_observed_in_schema': False,
                              'step_through_stride': None,
+                             'step_through_overlap': None,
                              'include_subject_window_counts_in_batch': False,
                              '_target_': 'meds_torchdata.config.MEDSTorchDataConfig'},
                        group=None,
@@ -226,6 +281,7 @@ class MEDSTorchDataConfig:
              'batch_mode': <BatchMode.SM: 'SM'>,
              'include_window_last_observed_in_schema': False,
              'step_through_stride': None,
+             'step_through_overlap': None,
              'include_subject_window_counts_in_batch': False,
              '_target_': 'meds_torchdata.config.MEDSTorchDataConfig'}
             >>> from hydra.utils import instantiate
@@ -239,6 +295,7 @@ class MEDSTorchDataConfig:
                                 batch_mode=<BatchMode.SM: 'SM'>,
                                 include_window_last_observed_in_schema=False,
                                 step_through_stride=None,
+                                step_through_overlap=None,
                                 include_subject_window_counts_in_batch=False)
 
         Note that Hydra's CLI parameters with structured configs recognize that the `StrEnum` classes are
@@ -277,6 +334,7 @@ class MEDSTorchDataConfig:
                                 batch_mode=<BatchMode.SM: 'SM'>,
                                 include_window_last_observed_in_schema=False,
                                 step_through_stride=None,
+                                step_through_overlap=None,
                                 include_subject_window_counts_in_batch=False)
 
         You can also add the config to a group
@@ -294,6 +352,7 @@ class MEDSTorchDataConfig:
                              'batch_mode': <BatchMode.SM: 'SM'>,
                              'include_window_last_observed_in_schema': False,
                              'step_through_stride': None,
+                             'step_through_overlap': None,
                              'include_subject_window_counts_in_batch': False,
                              '_target_': 'meds_torchdata.config.MEDSTorchDataConfig'},
                        group='my_group/my_subgroup',
@@ -354,10 +413,19 @@ class MEDSTorchDataConfig:
                 )
 
         if self.seq_sampling_strategy == SubsequenceSamplingStrategy.STEP_THROUGH:
+            # Exactly one of `step_through_stride` or `step_through_overlap` must be set.
+            n_set = (self.step_through_stride is not None) + (self.step_through_overlap is not None)
+            if n_set != 1:
+                raise ValueError(
+                    "Exactly one of step_through_stride or step_through_overlap must be set when "
+                    "seq_sampling_strategy is STEP_THROUGH; got "
+                    f"step_through_stride={self.step_through_stride!r}, "
+                    f"step_through_overlap={self.step_through_overlap!r}."
+                )
             # `bool` is a subclass of `int`, so `isinstance(True, int)` is `True`. Reject
             # `bool` explicitly so `step_through_stride=True` doesn't silently behave like
-            # stride 1.
-            if (
+            # stride 1 (or `step_through_overlap=True` like overlap 1).
+            if self.step_through_stride is not None and (
                 isinstance(self.step_through_stride, bool)
                 or not isinstance(self.step_through_stride, int)
                 or self.step_through_stride <= 0
@@ -366,11 +434,26 @@ class MEDSTorchDataConfig:
                     "step_through_stride must be a positive integer when seq_sampling_strategy is "
                     f"STEP_THROUGH; got {self.step_through_stride!r}."
                 )
-        elif self.step_through_stride is not None:
-            raise ValueError(
-                "step_through_stride may only be set when seq_sampling_strategy is STEP_THROUGH; "
-                f"got strategy {self.seq_sampling_strategy} with stride {self.step_through_stride!r}."
-            )
+            if self.step_through_overlap is not None and (
+                isinstance(self.step_through_overlap, bool)
+                or not isinstance(self.step_through_overlap, int)
+                or self.step_through_overlap < 0
+            ):
+                raise ValueError(
+                    "step_through_overlap must be a non-negative integer when seq_sampling_strategy "
+                    f"is STEP_THROUGH; got {self.step_through_overlap!r}."
+                )
+        else:
+            if self.step_through_stride is not None:
+                raise ValueError(
+                    "step_through_stride may only be set when seq_sampling_strategy is STEP_THROUGH; "
+                    f"got strategy {self.seq_sampling_strategy} with stride {self.step_through_stride!r}."
+                )
+            if self.step_through_overlap is not None:
+                raise ValueError(
+                    "step_through_overlap may only be set when seq_sampling_strategy is STEP_THROUGH; "
+                    f"got strategy {self.seq_sampling_strategy} with overlap {self.step_through_overlap!r}."
+                )
 
     @property
     def code_metadata_fp(self) -> Path:
@@ -481,6 +564,7 @@ class MEDSTorchDataConfig:
         data: JointNestedRaggedTensorDict,
         n_static_seq_els: int | None = None,
         rng: np.random.Generator | int | None = None,
+        explicit_end: int | None = None,
     ) -> JointNestedRaggedTensorDict:
         """This processes the dynamic data for a subject, including subsampling and flattening.
 
@@ -491,6 +575,16 @@ class MEDSTorchDataConfig:
                 `None`.
             rng: The random seed to use for subsequence sampling. If `None`, the default rng is used. If an
                 integer, a new rng is created with that seed.
+            explicit_end: An optional measurement-level end index for the window. When set,
+                `process_dynamic_data` returns
+                `data[max(0, explicit_end - effective_max_seq_len) : explicit_end]` after the
+                mode-appropriate flatten, bypassing the sampler entirely. This is the
+                `STEP_THROUGH`+`BatchMode.SM` path: the dataset's index expansion pre-computes
+                per-window measurement ends that can terminate mid-event, and passes each
+                one through here so the window is measurement-level precise regardless of how
+                many measurements an event has. `None` for every other caller — including
+                `STEP_THROUGH` in SEM mode, which goes through the normal
+                `STEP_THROUGH → TO_END` sampler path.
 
         Returns:
             The processed dynamic data, still in a `JointNestedRaggedTensorDict` format.
@@ -698,10 +792,17 @@ class MEDSTorchDataConfig:
 
             max_seq_len -= n_static_seq_els
 
-        st = self.seq_sampling_strategy.subsample_st_offset(seq_len, max_seq_len, rng=rng)
-        if st is None:
-            st = 0
-        end = st + max_seq_len
+        if explicit_end is not None:
+            # STEP_THROUGH + SM passes the measurement-level end of the window directly, so
+            # we bypass the sampler and take `[end - max_seq_len : end]` of the flattened
+            # tensor. `max_seq_len` has already been reduced for PREPEND above.
+            end = explicit_end
+            st = end - max_seq_len
+        else:
+            st = self.seq_sampling_strategy.subsample_st_offset(seq_len, max_seq_len, rng=rng)
+            if st is None:
+                st = 0
+            end = st + max_seq_len
 
         # Clamp the resulting slice: `BALANCED_RANDOM` can return a negative `st` so the
         # window overhangs the left boundary (yielding a uniform per-event inclusion

--- a/src/meds_torchdata/config.py
+++ b/src/meds_torchdata/config.py
@@ -443,6 +443,17 @@ class MEDSTorchDataConfig:
                 `None`.
             rng: The random seed to use for subsequence sampling. If `None`, the default rng is used. If an
                 integer, a new rng is created with that seed.
+            explicit_window: An optional pre-computed `(st, end)` slice in the units used by the
+                sampling strategies — that is, events in `BatchMode.SEM` and post-flatten
+                measurements in `BatchMode.SM`. When provided, `process_dynamic_data` honors this
+                slice directly instead of asking the strategy's `subsample_st_offset` for a
+                random start, so it bypasses the RNG entirely. This is used by
+                `STEP_THROUGH` sampling, where `MEDSPytorchDataset` pre-computes one window per
+                dataset element at init time. The provided `end` is still clamped against the
+                effective maximum — `min(seq_len, end, st + max_seq_len)` with `max_seq_len`
+                already reduced by `n_static_seq_els` in `PREPEND` mode — so the concatenated
+                `[static; dynamic]` sample can never exceed `config.max_seq_len` even if the
+                caller passes an oversized window.
 
         Returns:
             The processed dynamic data, still in a `JointNestedRaggedTensorDict` format.

--- a/src/meds_torchdata/config.py
+++ b/src/meds_torchdata/config.py
@@ -127,6 +127,17 @@ class MEDSTorchDataConfig:
     # Extra output
     include_window_last_observed_in_schema: bool = False
 
+    # STEP_THROUGH sampling-specific options.
+    # - `step_through_stride`: stride (in sequence elements, matching the units of `max_seq_len`)
+    #   between consecutive windows. Must be a positive integer when `seq_sampling_strategy ==
+    #   STEP_THROUGH`. Must be `None` for all other strategies.
+    # - `include_subject_window_counts_in_batch`: when True, the collated `MEDSTorchBatch` will
+    #   populate its `n_subject_windows` tensor (shape `[batch_size]`) with the number of
+    #   dataset elements each sample's subject expands into, so downstream losses can reweight
+    #   by `1 / n_subject_windows` to undo step-through oversampling of long sequences.
+    step_through_stride: int | None = None
+    include_subject_window_counts_in_batch: bool = False
+
     @classmethod
     def add_to_config_store(cls, group: str | None = None):
         """Adds this class to the Hydra config store such that instantiation will create it natively.
@@ -147,6 +158,8 @@ class MEDSTorchDataConfig:
                              'task_labels_dir': None,
                              'batch_mode': <BatchMode.SM: 'SM'>,
                              'include_window_last_observed_in_schema': False,
+                             'step_through_stride': None,
+                             'include_subject_window_counts_in_batch': False,
                              '_target_': 'meds_torchdata.config.MEDSTorchDataConfig'},
                        group=None,
                        package=None,
@@ -170,6 +183,8 @@ class MEDSTorchDataConfig:
              'task_labels_dir': None,
              'batch_mode': <BatchMode.SM: 'SM'>,
              'include_window_last_observed_in_schema': False,
+             'step_through_stride': None,
+             'include_subject_window_counts_in_batch': False,
              '_target_': 'meds_torchdata.config.MEDSTorchDataConfig'}
             >>> from hydra.utils import instantiate
             >>> instantiate(cfg)
@@ -180,7 +195,9 @@ class MEDSTorchDataConfig:
                                 static_inclusion_mode=<StaticInclusionMode.INCLUDE: 'include'>,
                                 task_labels_dir=None,
                                 batch_mode=<BatchMode.SM: 'SM'>,
-                                include_window_last_observed_in_schema=False)
+                                include_window_last_observed_in_schema=False,
+                                step_through_stride=None,
+                                include_subject_window_counts_in_batch=False)
 
         Note that Hydra's CLI parameters with structured configs recognize that the `StrEnum` classes are
         enums, but fails to recognize that they accept lowercased names as the names of the class members are
@@ -216,7 +233,9 @@ class MEDSTorchDataConfig:
                                 static_inclusion_mode=<StaticInclusionMode.INCLUDE: 'include'>,
                                 task_labels_dir=None,
                                 batch_mode=<BatchMode.SM: 'SM'>,
-                                include_window_last_observed_in_schema=False)
+                                include_window_last_observed_in_schema=False,
+                                step_through_stride=None,
+                                include_subject_window_counts_in_batch=False)
 
         You can also add the config to a group
 
@@ -232,6 +251,8 @@ class MEDSTorchDataConfig:
                              'task_labels_dir': None,
                              'batch_mode': <BatchMode.SM: 'SM'>,
                              'include_window_last_observed_in_schema': False,
+                             'step_through_stride': None,
+                             'include_subject_window_counts_in_batch': False,
                              '_target_': 'meds_torchdata.config.MEDSTorchDataConfig'},
                        group='my_group/my_subgroup',
                        package=None,
@@ -289,6 +310,18 @@ class MEDSTorchDataConfig:
                     "not permitted! This is because there is no use-case we know of where you would want to "
                     "do this. If you disagree, please let us know via a GitHub issue."
                 )
+
+        if self.seq_sampling_strategy == SubsequenceSamplingStrategy.STEP_THROUGH:
+            if not isinstance(self.step_through_stride, int) or self.step_through_stride <= 0:
+                raise ValueError(
+                    "step_through_stride must be a positive integer when seq_sampling_strategy is "
+                    f"STEP_THROUGH; got {self.step_through_stride!r}."
+                )
+        elif self.step_through_stride is not None:
+            raise ValueError(
+                "step_through_stride may only be set when seq_sampling_strategy is STEP_THROUGH; "
+                f"got strategy {self.seq_sampling_strategy} with stride {self.step_through_stride!r}."
+            )
 
     @property
     def code_metadata_fp(self) -> Path:
@@ -399,6 +432,7 @@ class MEDSTorchDataConfig:
         data: JointNestedRaggedTensorDict,
         n_static_seq_els: int | None = None,
         rng: np.random.Generator | int | None = None,
+        explicit_window: tuple[int, int] | None = None,
     ) -> JointNestedRaggedTensorDict:
         """This processes the dynamic data for a subject, including subsampling and flattening.
 
@@ -581,6 +615,14 @@ class MEDSTorchDataConfig:
                 )
 
             max_seq_len -= n_static_seq_els
+
+        if explicit_window is not None:
+            # STEP_THROUGH hands us a pre-computed `(st, end)` window from the dataset-level
+            # expansion — honor it directly rather than asking the (non-deterministic) sampler.
+            st, end = explicit_window
+            st = max(0, st)
+            end = min(seq_len, end)
+            return data[st:end]
 
         st = self.seq_sampling_strategy.subsample_st_offset(seq_len, max_seq_len, rng=rng)
 

--- a/src/meds_torchdata/config.py
+++ b/src/meds_torchdata/config.py
@@ -26,13 +26,63 @@ class MEDSTorchDataConfig:
     """A data class for storing configuration options for building a PyTorch dataset from a MEDS dataset.
 
     Attributes:
-        max_seq_len: The maximum length of sequences to yield from the dataset.
-        seq_sampling_strategy: The subsequence sampling strategy for the dataset.
+        tensorized_cohort_dir: Path to the root of a tokenized-and-tensorized MEDS cohort
+            produced by `MTD_preprocess`. The directory must contain `tokenization/schemas/`
+            and `data/` subdirectories.
+        max_seq_len: The maximum length (in the batch mode's natural unit — events in SEM
+            mode, measurements in SM mode) of sequences yielded from the dataset. Samplers
+            that produce fixed-width windows will use this as the width; `RANDOM` and
+            `BALANCED_RANDOM` treat it as the upper bound.
+        seq_sampling_strategy: The subsequence sampling strategy — one of
+            `SubsequenceSamplingStrategy.{RANDOM, BALANCED_RANDOM, TO_END, FROM_START,
+            STEP_THROUGH}`. Task-mode datasets (`task_labels_dir` set) are restricted to
+            `TO_END`.
+        padding_side: Which side of short sequences to pad when collating into a batch
+            (`LEFT` or `RIGHT`). Defaults to `RIGHT`; set to `LEFT` for autoregressive
+            generation models.
+        static_inclusion_mode: How to surface per-subject static measurements in the
+            collated batch — `OMIT` (drop), `INCLUDE` (separate `static_code`/`static_*`
+            tensors in the batch), or `PREPEND` (concatenate static elements onto the front
+            of the dynamic sequence). In `PREPEND` mode the effective dynamic window shrinks
+            to leave room for the static elements.
+        task_labels_dir: Optional path to a directory of MEDS Label parquet files. When set,
+            the dataset yields one sample per (subject, prediction_time) label with the
+            sampling strategy fixed to `TO_END`.
+        batch_mode: Whether the collated batch keeps the event/measurement structure
+            (`SEM` = Subject-Event-Measurement 3D tensors) or flattens measurements into a
+            single sequence dimension (`SM` = Subject-Measurement 2D tensors). The unit of
+            `max_seq_len` and every step-through parameter follows this choice.
+        include_window_last_observed_in_schema: When True, the `schema_df` helper adds a
+            `window_last_observed` column containing the timestamp of the last event included
+            in each window. Only meaningful for deterministic samplers (`TO_END`,
+            `FROM_START`); skipped for the random samplers because they have no deterministic
+            last event.
+        step_through_stride: Absolute number of sequence elements (events in SEM mode,
+            measurements in SM mode) to advance between consecutive `STEP_THROUGH` windows.
+            Must be a positive integer; `bool` is explicitly rejected even though it is a
+            subclass of `int`. Mutually exclusive with `step_through_overlap`: exactly one
+            of the two must be set when `seq_sampling_strategy == STEP_THROUGH`, and both
+            must be `None` for every other strategy.
+        step_through_overlap: Alternative to `step_through_stride` that specifies the number
+            of elements consecutive `STEP_THROUGH` windows should share. Equivalent to
+            `stride = effective_window - overlap`, but more convenient when the user wants
+            "no overlap" (`overlap=0`) or a fixed overlap because the effective window can
+            vary per subject in `SM + PREPEND`. Must be a non-negative integer strictly less
+            than the per-subject effective window.
+        include_subject_window_counts_in_batch: When True, `MEDSPytorchDataset.collate`
+            populates the `n_subject_windows` field of the returned `MEDSTorchBatch` with the
+            number of dataset elements each sample's subject expands into. Intended for
+            per-sample loss reweighting (`1 / n_subject_windows`) to undo `STEP_THROUGH`
+            oversampling — subjects with longer sequences get expanded into more windows, so
+            reweighting by the inverse count restores a per-subject uniform loss.
 
     Raises:
         FileNotFoundError: If the task_labels_dir or the tensorized_cohort_dir is not a valid directory.
         ValueError: If the subsequence sampling strategy or static inclusion mode is not valid.
         ValueError: If the task_labels_dir is specified but the subsequence sampling strategy is not TO_END.
+        ValueError: If `step_through_stride` / `step_through_overlap` is set without the
+            `STEP_THROUGH` strategy, if both are set simultaneously, or if either is an
+            invalid type (including `bool`) or out of range.
 
     Examples:
         >>> import tempfile
@@ -792,17 +842,18 @@ class MEDSTorchDataConfig:
 
             max_seq_len -= n_static_seq_els
 
-        if explicit_end is not None:
-            # STEP_THROUGH + SM passes the measurement-level end of the window directly, so
-            # we bypass the sampler and take `[end - max_seq_len : end]` of the flattened
-            # tensor. `max_seq_len` has already been reduced for PREPEND above.
-            end = explicit_end
-            st = end - max_seq_len
-        else:
-            st = self.seq_sampling_strategy.subsample_st_offset(seq_len, max_seq_len, rng=rng)
-            if st is None:
-                st = 0
-            end = st + max_seq_len
+        # `explicit_end` (set by `STEP_THROUGH` in `BatchMode.SM`) semantically means "don't
+        # go past this measurement". We can honor it by telling the sampler to act as if the
+        # sequence were truncated there — the `STEP_THROUGH → TO_END` delegation in
+        # `subsample_st_offset` then naturally returns `explicit_end - max_seq_len`, so the
+        # resulting window is `[explicit_end - max_seq_len, explicit_end)` without any
+        # sampler-bypass branch. `min(seq_len, ...)` guards against an over-ambitious caller.
+        effective_seq_len = min(seq_len, explicit_end) if explicit_end is not None else seq_len
+
+        st = self.seq_sampling_strategy.subsample_st_offset(effective_seq_len, max_seq_len, rng=rng)
+        if st is None:
+            st = 0
+        end = st + max_seq_len
 
         # Clamp the resulting slice: `BALANCED_RANDOM` can return a negative `st` so the
         # window overhangs the left boundary (yielding a uniform per-event inclusion

--- a/src/meds_torchdata/extensions/lightning_datamodule.py
+++ b/src/meds_torchdata/extensions/lightning_datamodule.py
@@ -52,10 +52,10 @@ class Datamodule(L.LightningDataModule, Generic[DatasetT]):
         0
         >>> train_dataloader = D.train_dataloader()
         >>> next(iter(train_dataloader))
-        MEDSTorchBatch(code=tensor([[...]]), ..., boolean_value=None)
+        MEDSTorchBatch(code=tensor([[...]]), ..., n_subject_windows=None)
         >>> val_dataloader = D.val_dataloader()
         >>> next(iter(val_dataloader))
-        MEDSTorchBatch(code=tensor([[ 5,  3, 10, 11,  4]]), ..., boolean_value=None)
+        MEDSTorchBatch(code=tensor([[ 5,  3, 10, 11,  4]]), ..., n_subject_windows=None)
 
     You can also set the number of workers to a non-zero value, and it will be applied to the created
     dataloaders, along with batch size, through the `shared_dataloader_kwargs` property.
@@ -65,7 +65,7 @@ class Datamodule(L.LightningDataModule, Generic[DatasetT]):
         {'batch_size': 1, 'num_workers': 4}
         >>> test_dataloader = D.test_dataloader()
         >>> next(iter(test_dataloader))
-        MEDSTorchBatch(code=tensor([[ 5,  2, 10, 11, 10, 11, 10, 11,  4]]), ..., boolean_value=None)
+        MEDSTorchBatch(code=tensor([[ 5,  2, 10, 11, 10, 11, 10, 11,  4]]), ..., n_subject_windows=None)
 
     You can also set the pin_memory flag to True, and it will be applied to the created dataloaders.
 
@@ -74,7 +74,7 @@ class Datamodule(L.LightningDataModule, Generic[DatasetT]):
         {'batch_size': 1, 'pin_memory': True}
         >>> test_dataloader = D.test_dataloader()
         >>> next(iter(test_dataloader))
-        MEDSTorchBatch(code=tensor([[ 5,  2, 10, 11, 10, 11, 10, 11,  4]]), ..., boolean_value=None)
+        MEDSTorchBatch(code=tensor([[ 5,  2, 10, 11, 10, 11, 10, 11,  4]]), ..., n_subject_windows=None)
 
     You can also override the dataset class used by the datamodule via the `data_class` argument. This is
     useful for injecting convenience helpers or light instrumentation while retaining the core

--- a/src/meds_torchdata/preprocessing/tokenization.py
+++ b/src/meds_torchdata/preprocessing/tokenization.py
@@ -110,7 +110,11 @@ def extract_statics_and_schema(df: pl.LazyFrame) -> pl.LazyFrame:
 
     Returns:
         A `pl.LazyFrame` object containing the static data and the unique times of the subject, grouped
-        by subject as lists, in the same order as the subject IDs occurred in the original file.
+        by subject as lists, in the same order as the subject IDs occurred in the original file. Each
+        subject also carries a `measurements_per_event` list, parallel to the `time` list, giving the
+        number of raw measurements (rows in the source dataframe) at each unique timestamp. This column
+        is needed by `STEP_THROUGH` sampling in `BatchMode.SM` to map measurement-level window ends back
+        to event-level indices.
 
     Examples:
         >>> from datetime import datetime
@@ -123,7 +127,7 @@ def extract_statics_and_schema(df: pl.LazyFrame) -> pl.LazyFrame:
         ...     "numeric_value": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]
         ... }).lazy()
         >>> df = extract_statics_and_schema(df).collect()
-        >>> df.drop("time")
+        >>> df.drop("time", "measurements_per_event")
         shape: (2, 4)
         ┌────────────┬─────────────┬──────────────────────┬─────────────────────┐
         │ subject_id ┆ static_code ┆ static_numeric_value ┆ start_time          │
@@ -133,17 +137,19 @@ def extract_statics_and_schema(df: pl.LazyFrame) -> pl.LazyFrame:
         │ 1          ┆ [100]       ┆ [1.0]                ┆ 2021-01-01 00:00:00 │
         │ 2          ┆ [200]       ┆ [5.0]                ┆ 2021-01-02 00:00:00 │
         └────────────┴─────────────┴──────────────────────┴─────────────────────┘
-        >>> df.select("subject_id", "time").explode("time")
-        shape: (3, 2)
-        ┌────────────┬─────────────────────┐
-        │ subject_id ┆ time                │
-        │ ---        ┆ ---                 │
-        │ i64        ┆ datetime[μs]        │
-        ╞════════════╪═════════════════════╡
-        │ 1          ┆ 2021-01-01 00:00:00 │
-        │ 1          ┆ 2021-01-13 00:00:00 │
-        │ 2          ┆ 2021-01-02 00:00:00 │
-        └────────────┴─────────────────────┘
+        >>> df.select("subject_id", "time", "measurements_per_event").explode(
+        ...     "time", "measurements_per_event"
+        ... )
+        shape: (3, 3)
+        ┌────────────┬─────────────────────┬────────────────────────┐
+        │ subject_id ┆ time                ┆ measurements_per_event │
+        │ ---        ┆ ---                 ┆ ---                    │
+        │ i64        ┆ datetime[μs]        ┆ u32                    │
+        ╞════════════╪═════════════════════╪════════════════════════╡
+        │ 1          ┆ 2021-01-01 00:00:00 ┆ 2                      │
+        │ 1          ┆ 2021-01-13 00:00:00 ┆ 1                      │
+        │ 2          ┆ 2021-01-02 00:00:00 ┆ 2                      │
+        └────────────┴─────────────────────┴────────────────────────┘
         >>> df = pl.DataFrame({
         ...     "subject_id": [1, 1, 1, 1, 2, 2, 2],
         ...     "time": [
@@ -153,7 +159,7 @@ def extract_statics_and_schema(df: pl.LazyFrame) -> pl.LazyFrame:
         ...     "numeric_value": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]
         ... }).lazy()
         >>> df = extract_statics_and_schema(df).collect()
-        >>> df.drop("time")
+        >>> df.drop("time", "measurements_per_event")
         shape: (2, 4)
         ┌────────────┬─────────────┬──────────────────────┬─────────────────────┐
         │ subject_id ┆ static_code ┆ static_numeric_value ┆ start_time          │
@@ -163,19 +169,21 @@ def extract_statics_and_schema(df: pl.LazyFrame) -> pl.LazyFrame:
         │ 1          ┆ null        ┆ null                 ┆ 2020-01-01 00:00:00 │
         │ 2          ┆ null        ┆ null                 ┆ 2020-01-01 00:00:00 │
         └────────────┴─────────────┴──────────────────────┴─────────────────────┘
-        >>> df.select("subject_id", "time").explode("time")
-        shape: (5, 2)
-        ┌────────────┬─────────────────────┐
-        │ subject_id ┆ time                │
-        │ ---        ┆ ---                 │
-        │ i64        ┆ datetime[μs]        │
-        ╞════════════╪═════════════════════╡
-        │ 1          ┆ 2020-01-01 00:00:00 │
-        │ 1          ┆ 2021-01-01 00:00:00 │
-        │ 1          ┆ 2021-01-13 00:00:00 │
-        │ 2          ┆ 2020-01-01 00:00:00 │
-        │ 2          ┆ 2021-01-02 00:00:00 │
-        └────────────┴─────────────────────┘
+        >>> df.select("subject_id", "time", "measurements_per_event").explode(
+        ...     "time", "measurements_per_event"
+        ... )
+        shape: (5, 3)
+        ┌────────────┬─────────────────────┬────────────────────────┐
+        │ subject_id ┆ time                ┆ measurements_per_event │
+        │ ---        ┆ ---                 ┆ ---                    │
+        │ i64        ┆ datetime[μs]        ┆ u32                    │
+        ╞════════════╪═════════════════════╪════════════════════════╡
+        │ 1          ┆ 2020-01-01 00:00:00 ┆ 1                      │
+        │ 1          ┆ 2021-01-01 00:00:00 ┆ 2                      │
+        │ 1          ┆ 2021-01-13 00:00:00 ┆ 1                      │
+        │ 2          ┆ 2020-01-01 00:00:00 ┆ 1                      │
+        │ 2          ┆ 2021-01-02 00:00:00 ┆ 2                      │
+        └────────────┴─────────────────────┴────────────────────────┘
     """
 
     static, dynamic = split_static_and_dynamic(df)
@@ -186,10 +194,19 @@ def extract_statics_and_schema(df: pl.LazyFrame) -> pl.LazyFrame:
         pl.col("numeric_value").alias("static_numeric_value"),
     )
 
-    # This collects the unique times for each subject.
-    schema_by_subject = dynamic.group_by("subject_id", maintain_order=True).agg(
-        pl.col("time").min().alias("start_time"),
-        pl.col("time").unique(maintain_order=True),
+    # Collect unique times per subject, along with the number of measurements at each timestamp (needed
+    # by STEP_THROUGH sampling in SM mode to map measurement-level window ends back to event indices
+    # without re-loading the dynamic tensor). The two-step group_by preserves source order, so the
+    # `time` and `measurements_per_event` lists line up element-for-element.
+    schema_by_subject = (
+        dynamic.group_by(["subject_id", "time"], maintain_order=True)
+        .agg(pl.len().alias("measurements_per_event"))
+        .group_by("subject_id", maintain_order=True)
+        .agg(
+            pl.col("time").min().alias("start_time"),
+            pl.col("time"),
+            pl.col("measurements_per_event"),
+        )
     )
 
     return static_by_subject.join(schema_by_subject, on="subject_id", how="full", coalesce=True)

--- a/src/meds_torchdata/pytorch_dataset.py
+++ b/src/meds_torchdata/pytorch_dataset.py
@@ -583,7 +583,27 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
         """
 
         subject_id, end_idx = self.index[idx]
-        dynamic_data, static_data = self.load_subject_data(subject_id=subject_id, st=0, end=end_idx)
+
+        # In SEM + step-through, the stored `(window_st, window_end)` is already in event
+        # units, so we can load only that event slice instead of reading the full `[0,
+        # end_idx)` prefix for every window of the same subject. This turns an `O(N *
+        # end_idx)` total read (for N windows per subject) into `O(N * window_size)`.
+        # In SM mode the window is in post-flatten measurement units, which can't be mapped
+        # back to an event range without loading the full prefix first, so step-through SM
+        # keeps the prefix-load path.
+        explicit_window: tuple[int, int] | None = None
+        if self.step_through_windows is not None and self.config.batch_mode == BatchMode.SEM:
+            window_st, window_end = self.step_through_windows[idx]
+            dynamic_data, static_data = self.load_subject_data(
+                subject_id=subject_id, st=window_st, end=window_end
+            )
+            # The loaded slice already *is* the window; tell `process_dynamic_data` to
+            # consume all of it (rebased to 0).
+            explicit_window = (0, window_end - window_st)
+        else:
+            dynamic_data, static_data = self.load_subject_data(subject_id=subject_id, st=0, end=end_idx)
+            if self.step_through_windows is not None:
+                explicit_window = self.step_through_windows[idx]
 
         match self.config.static_inclusion_mode:
             case StaticInclusionMode.OMIT:
@@ -598,8 +618,6 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
             case StaticInclusionMode.PREPEND:
                 n_static_seq_els = len(static_data.code) if self.config.batch_mode == BatchMode.SM else 1
                 out = {"n_static_seq_els": n_static_seq_els}
-
-        explicit_window = self.step_through_windows[idx] if self.step_through_windows is not None else None
 
         dynamic_data = self.config.process_dynamic_data(
             dynamic_data,

--- a/src/meds_torchdata/pytorch_dataset.py
+++ b/src/meds_torchdata/pytorch_dataset.py
@@ -240,20 +240,11 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
         """
 
         stride = self.config.step_through_stride
+        n_subjects_before = len(self.index)
 
         expanded_index: list[tuple[int, int]] = []
         expanded_windows: list[tuple[int, int]] = []
         expanded_counts: list[int] = []
-
-        # Oversampling warning: the subject with the longest sequence dominates training when
-        # step-through stride is small. Surface that explicitly before doing the heavy work.
-        logger.warning(
-            "STEP_THROUGH sampling expands each subject into ceil(max(0, seq_len - "
-            "max_seq_len) / stride) + 1 dataset elements, which means subjects with longer "
-            "sequences are oversampled relative to shorter ones. To undo the oversampling at "
-            "loss time, set MEDSTorchDataConfig.include_subject_window_counts_in_batch=True "
-            "and use `1 / batch.n_subject_windows` as a per-sample loss weight."
-        )
 
         for subject_id, end_idx in self.index:
             seq_len = self._step_through_seq_len_for(subject_id, end_idx)
@@ -306,14 +297,27 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
         self.index = expanded_index
         self.step_through_windows = expanded_windows
         self.step_through_window_counts = expanded_counts
-        logger.info(
-            "STEP_THROUGH expanded %d subjects into %d dataset elements (stride=%d, "
-            "max_seq_len=%d, max windows per subject=%d).",
-            len({s for s, _ in expanded_index}),
-            len(expanded_index),
+
+        # Oversampling warning — emitted after the expansion loop so the numbers we report
+        # are the actual observed stats rather than a closed-form guess. In PREPEND mode the
+        # effective dynamic window is `max_seq_len - n_static_seq_els` (and in SM+PREPEND that
+        # varies per subject), so the old closed-form formula in terms of `max_seq_len` was
+        # not the formula the expansion actually used.
+        n_elements = len(expanded_index)
+        max_windows = max(expanded_counts) if expanded_counts else 0
+        mean_windows = n_elements / n_subjects_before if n_subjects_before else 0.0
+        logger.warning(
+            "STEP_THROUGH sampling expanded %d subjects into %d dataset elements (stride=%d, "
+            "mean windows per subject=%.1f, max windows per subject=%d). Subjects with "
+            "longer dynamic sequences are oversampled relative to shorter ones by a factor "
+            "equal to their per-subject window count. To undo the oversampling at loss time, "
+            "set MEDSTorchDataConfig.include_subject_window_counts_in_batch=True and use "
+            "`1 / batch.n_subject_windows` as a per-sample loss weight.",
+            n_subjects_before,
+            n_elements,
             stride,
-            self.config.max_seq_len,
-            max(expanded_counts) if expanded_counts else 0,
+            mean_windows,
+            max_windows,
         )
 
     def _effective_max_seq_len_for(self, subject_id: int) -> int:

--- a/src/meds_torchdata/pytorch_dataset.py
+++ b/src/meds_torchdata/pytorch_dataset.py
@@ -411,16 +411,8 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
                     expanded_index.append((subject_id, event_end))
                     expanded_meas_ends.append(meas_end)
 
-        # Step-through is not allowed in task mode (the config enforces TO_END when a task is
-        # set) because labels correspond to specific end-of-window predictions that can't be
-        # remapped onto arbitrarily-placed mid-sequence windows. The check here makes the
-        # invariant explicit.
-        if self.has_task_labels:  # pragma: no cover -- prevented by MEDSTorchDataConfig validation
-            raise ValueError(
-                "STEP_THROUGH sampling is not compatible with task-mode datasets; labels "
-                "correspond to specific end-of-window predictions and cannot be mapped onto "
-                "arbitrarily-placed mid-sequence windows."
-            )
+        # (Task mode is already rejected at config time, since `task_labels_dir is not None`
+        # forces the sampling strategy to `TO_END`. No need to re-check here.)
 
         self.index = expanded_index
         self._windows_per_subject = windows_per_subject
@@ -451,6 +443,31 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
         `config.step_through_overlap` is set instead, the stride is computed relative to the
         per-subject effective window so that consecutive windows share exactly the requested
         overlap regardless of how `PREPEND` shrinks the window for that subject.
+
+        Examples:
+            >>> import dataclasses
+            >>> stride_cfg = dataclasses.replace(
+            ...     sample_dataset_config,
+            ...     max_seq_len=3,
+            ...     seq_sampling_strategy="step_through",
+            ...     step_through_stride=2,
+            ...     batch_mode="SEM",
+            ...     static_inclusion_mode="omit",
+            ... )
+            >>> stride_pyd = MEDSPytorchDataset(stride_cfg, split="train")
+            >>> stride_pyd._resolve_step_through_stride_for(239684, effective_window=3)
+            2
+
+            With `step_through_overlap` the stride varies per subject to honor the
+            requested overlap count relative to that subject's effective window:
+
+            >>> overlap_cfg = dataclasses.replace(stride_cfg, step_through_stride=None,
+            ...                                   step_through_overlap=1)
+            >>> overlap_pyd = MEDSPytorchDataset(overlap_cfg, split="train")
+            >>> overlap_pyd._resolve_step_through_stride_for(239684, effective_window=3)
+            2
+            >>> overlap_pyd._resolve_step_through_stride_for(239684, effective_window=5)
+            4
         """
 
         if self.config.step_through_stride is not None:
@@ -464,6 +481,31 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
         The first window ends at `effective_window` (so it contains `effective_window`
         events); subsequent windows each shift forward by `stride` events; the final window
         is anchored to `end_idx` so the last event is always covered regardless of stride.
+
+        Examples:
+            Typical overlapping walk: `end_idx=8, stride=2, effective_window=3` produces
+            windows ending at events `[3, 5, 7, 8]` — the last one is tail-anchored to
+            `end_idx` so the final event is always covered:
+
+            >>> MEDSPytorchDataset._step_through_event_ends_sem(8, stride=2, effective_window=3)
+            [3, 5, 7, 8]
+
+            Contiguous (`stride == effective_window`) walk:
+
+            >>> MEDSPytorchDataset._step_through_event_ends_sem(8, stride=3, effective_window=3)
+            [3, 6, 8]
+
+            Short subject (`end_idx <= effective_window`) — single window covering everything:
+
+            >>> MEDSPytorchDataset._step_through_event_ends_sem(3, stride=2, effective_window=3)
+            [3]
+            >>> MEDSPytorchDataset._step_through_event_ends_sem(2, stride=2, effective_window=3)
+            [2]
+
+            Stride-divides-gap — no duplicate tail anchor:
+
+            >>> MEDSPytorchDataset._step_through_event_ends_sem(7, stride=2, effective_window=3)
+            [3, 5, 7]
         """
 
         if end_idx <= effective_window:
@@ -484,6 +526,35 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
         prefix contains it via `np.searchsorted` on the cumulative-measurement array — that
         becomes the `end` the loader reads from `self.index`, while the measurement-level
         end is returned separately for `self.step_through_meas_ends`.
+
+        Examples:
+            Subject 239684 in the `sample_dataset_config` fixture has 6 events flattening
+            to 11 measurements with per-event counts `[1, 3, 2, 2, 2, 1]`, so
+            `cum_meas = [0, 1, 4, 6, 8, 10, 11]`. With `effective_window=5, stride=3`, the
+            walk produces measurement ends `[5, 8, 11]`, each of which maps via
+            `searchsorted(cum_meas, meas_end, side="left")` to the smallest event index
+            whose prefix contains it. Note that window 2 (meas end `8`) maps to event `4`
+            because `cum_meas[4] == 8` exactly, while window 1 (meas end `5`) maps to event
+            `3` because `cum_meas[2] = 4 < 5 <= cum_meas[3] = 6`:
+
+            >>> import dataclasses
+            >>> sm_cfg = dataclasses.replace(
+            ...     sample_dataset_config,
+            ...     max_seq_len=5,
+            ...     seq_sampling_strategy="step_through",
+            ...     step_through_stride=3,
+            ...     batch_mode="SM",
+            ...     static_inclusion_mode="omit",
+            ... )
+            >>> sm_pyd = MEDSPytorchDataset(sm_cfg, split="train")
+            >>> sm_pyd._step_through_ends_sm(239684, stride=3, effective_window=5)
+            ([5, 8, 11], [3, 4, 6])
+
+            Short subject (total measurements `<= effective_window`) — single entry
+            covering the entire subject:
+
+            >>> sm_pyd._step_through_ends_sm(239684, stride=3, effective_window=20)
+            ([11], [6])
         """
 
         shard, subject_idx = self.subj_locations[subject_id]
@@ -517,9 +588,48 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
         """Return the dynamic-window size a step-through sample can reserve for this subject.
 
         This mirrors the `max_seq_len -= n_static_seq_els` adjustment inside
-        `MEDSTorchDataConfig.process_dynamic_data` for PREPEND mode — so that the resulting
-        `[static; dynamic]` sample after prepending still has length `<= config.max_seq_len`.
-        For every other static inclusion mode this just returns `config.max_seq_len`.
+        `MEDSTorchDataConfig.process_dynamic_data` for `PREPEND` mode — so that the
+        resulting `[static; dynamic]` sample after prepending still has length
+        `<= config.max_seq_len`. For every other static inclusion mode this returns
+        `config.max_seq_len` unchanged. In `SM + PREPEND` the reduction varies per subject
+        because `n_static_seq_els == len(static_code[subject_id])`.
+
+        Examples:
+            With the default `sample_dataset_config` (`max_seq_len=10`, SM batch mode,
+            `static_inclusion_mode=INCLUDE`), the effective window equals `max_seq_len`
+            unchanged for every subject:
+
+            >>> pyd = sample_pytorch_dataset
+            >>> pyd.config.max_seq_len
+            10
+            >>> pyd.config.batch_mode
+            <BatchMode.SM: 'SM'>
+            >>> pyd.config.static_inclusion_mode
+            <StaticInclusionMode.INCLUDE: 'include'>
+            >>> [pyd._effective_max_seq_len_for(s) for s in (239684, 1195293, 68729, 814703)]
+            [10, 10, 10, 10]
+
+            In `SM + PREPEND` the reduction is `len(static_code)` per subject — every
+            fixture subject has two static codes, so their effective window shrinks from
+            `10` to `8`:
+
+            >>> import dataclasses
+            >>> sm_prepend_cfg = dataclasses.replace(
+            ...     pyd.config, static_inclusion_mode="prepend"
+            ... )
+            >>> sm_prepend_pyd = MEDSPytorchDataset(sm_prepend_cfg, split="train")
+            >>> [sm_prepend_pyd._effective_max_seq_len_for(s) for s in (239684, 1195293)]
+            [8, 8]
+
+            In `SEM + PREPEND` the reduction is a flat `1` (one event slot reserved for the
+            prepended static event):
+
+            >>> sem_prepend_cfg = dataclasses.replace(
+            ...     pyd.config, batch_mode="SEM", static_inclusion_mode="prepend"
+            ... )
+            >>> sem_prepend_pyd = MEDSPytorchDataset(sem_prepend_cfg, split="train")
+            >>> [sem_prepend_pyd._effective_max_seq_len_for(s) for s in (239684, 1195293)]
+            [9, 9]
         """
 
         max_seq_len = self.config.max_seq_len

--- a/src/meds_torchdata/pytorch_dataset.py
+++ b/src/meds_torchdata/pytorch_dataset.py
@@ -378,6 +378,18 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
                 )
 
             stride = self._resolve_step_through_stride_for(subject_id, effective_window)
+            if stride <= 0:
+                # This only happens when `step_through_overlap` is set (it's relative to the
+                # per-subject effective window and can produce a non-positive stride if
+                # overlap >= effective_window). A plain stride is already validated to be
+                # positive at config time.
+                raise ValueError(
+                    f"step_through_overlap ({self.config.step_through_overlap}) must be "
+                    f"strictly less than the effective window width ({effective_window}) "
+                    f"for subject {subject_id}; got overlap >= effective window, which "
+                    "would produce a non-positive stride. Reduce step_through_overlap or "
+                    "increase max_seq_len."
+                )
             if stride > effective_window:
                 raise ValueError(
                     f"step_through stride ({stride}) exceeds the effective window width "
@@ -473,8 +485,6 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
         becomes the `end` the loader reads from `self.index`, while the measurement-level
         end is returned separately for `self.step_through_meas_ends`.
         """
-
-        import numpy as np  # local import to avoid touching the module-level import list
 
         shard, subject_idx = self.subj_locations[subject_id]
         schema_row = self.schema_dfs_by_shard[shard][subject_idx]

--- a/src/meds_torchdata/pytorch_dataset.py
+++ b/src/meds_torchdata/pytorch_dataset.py
@@ -207,15 +207,17 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
         )
         self.labels = self.schema_df[self.LABEL_COL] if self.has_task_labels else None
 
-        # Populated only when STEP_THROUGH sampling is active. For every index entry,
-        # `self.step_through_windows[i]` is a `(st, end)` slice applied to the dynamic data
-        # after the optional SM-mode flatten (so `st`, `end` are in events in SEM mode and in
-        # post-flatten measurements in SM mode). The number of dataset elements each subject
-        # expands into is cached as a simple `subject_id -> count` dict, which populates
-        # `MEDSTorchBatch.n_subject_windows` when
-        # `config.include_subject_window_counts_in_batch` is set.
-        self.step_through_windows: list[tuple[int, int]] | None = None
+        # STEP_THROUGH state:
+        # - `_windows_per_subject`: `subject_id -> number of dataset elements the subject
+        #   expands into`, populates `MEDSTorchBatch.n_subject_windows` when
+        #   `config.include_subject_window_counts_in_batch` is set.
+        # - `step_through_meas_ends`: parallel list to `self.index`, only populated in
+        #   `BatchMode.SM` step-through. Stores the measurement-level end of each window so
+        #   `process_dynamic_data` can slice mid-event via its `explicit_end` kwarg. `None`
+        #   in SEM mode because the event-level `end` in `self.index` plus TO_END sampling
+        #   is sufficient there.
         self._windows_per_subject: dict[int, int] | None = None
+        self.step_through_meas_ends: list[int] | None = None
         if self.config.seq_sampling_strategy == SubsequenceSamplingStrategy.STEP_THROUGH:
             self._expand_index_for_step_through()
 
@@ -223,23 +225,41 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
         """Expand `self.index` so that STEP_THROUGH sampling produces one entry per window.
 
         For each subject in the pre-expansion index, this walks a sliding window of size
-        `max_seq_len` across the permitted sequence with stride `step_through_stride`,
-        producing one dataset element per window. In SEM mode, window/stride are in events and
-        `seq_len = end_idx` (already known from the schema). In SM mode, the dynamic data is
-        flattened first, so we must load each subject's dynamic data once to compute the true
-        per-subject measurement count before expansion. A warning is logged about the resulting
-        oversampling of subjects with longer sequences; set
+        `max_seq_len` across the permitted sequence with either a user-supplied
+        `step_through_stride` or a user-supplied `step_through_overlap`, producing one
+        dataset element per window.
+
+        The walk is expressed in the same unit as `max_seq_len`: events in `BatchMode.SEM`,
+        measurements in `BatchMode.SM`. In SM mode this means the window ends can fall
+        mid-event — for example a subject with two events [3, 5] measurements and
+        `max_seq_len=4` with `step_through_stride=2` produces windows `[0:4)`, `[2:6)`, and
+        `[4:8)` — the second window ends in the middle of the second event. This is the
+        intentional Design B semantics: step-through walks the **measurement-level** sequence
+        regardless of event atomicity. See the class docstring for alternatives.
+
+        The per-subject measurement-level walk is powered by `measurements_per_event`, a new
+        preprocessing column that records the measurement count at each unique timestamp for
+        each subject. In SM mode we use `np.searchsorted` on the per-subject cumulative sum
+        to find the smallest event index whose prefix contains each target measurement end —
+        that's the `end` stored in `self.index` (for `load_subject_data`) — while the
+        measurement-level end itself is recorded in `self.step_through_meas_ends` and passed
+        through `MEDSTorchDataConfig.process_dynamic_data`'s `explicit_end` kwarg at sample
+        time.
+
+        Validation at construction time:
+        - `stride` (or the derived `effective_window - overlap`) must be positive.
+        - `stride <= effective_window` per subject, so consecutive windows overlap by
+          `effective_window - stride >= 0` elements and no data is skipped.
+        - For SM mode, the `measurements_per_event` column must exist on the schema parquet
+          (re-run preprocessing if it's missing from an older cohort).
+
+        A warning with observed expansion stats is logged on startup; set
         `config.include_subject_window_counts_in_batch=True` to surface per-sample window
         counts in the collated batch so downstream code can reweight losses.
 
-        When `static_inclusion_mode=PREPEND`, the effective window size is reduced by the
-        number of static sequence elements that will be prepended (1 event in SEM mode, or
-        `len(static_code)` measurements per subject in SM mode) so that the concatenated
-        [static; dynamic] sample still fits inside `config.max_seq_len`. This is the same
-        reduction applied by `MEDSTorchDataConfig.process_dynamic_data` for the other
-        sampling strategies.
-
         Examples:
+            Example 1 — SEM mode, event-level walk:
+
             >>> import dataclasses
             >>> cfg = dataclasses.replace(
             ...     sample_dataset_config,
@@ -250,24 +270,26 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
             ...     static_inclusion_mode="omit",
             ...     include_subject_window_counts_in_batch=True,
             ... )
-
-            `MEDSPytorchDataset.__init__` runs the expansion automatically. The four subjects
-            in the fixture have event counts of 6, 8, 3, and 3, so with window=3 and stride=2
-            the long subjects expand into multiple entries while the short ones contribute a
-            single window each:
-
             >>> pyd = MEDSPytorchDataset(cfg, split="train")
+
+            The four subjects in the fixture have event counts of 6, 8, 3, and 3. With
+            `max_seq_len=3, step_through_stride=2`, `self.index` has one entry per window —
+            each entry's `end` is the *window*'s final event. `self.step_through_meas_ends`
+            stays `None` in SEM mode because the sampler's `TO_END` semantics handle the
+            window end natively via event-level slicing.
+
             >>> pyd.index
-            [(239684, 6), (239684, 6), (239684, 6), (1195293, 8), (1195293, 8), (1195293, 8),
+            [(239684, 3), (239684, 5), (239684, 6), (1195293, 3), (1195293, 5), (1195293, 7),
              (1195293, 8), (68729, 3), (814703, 3)]
-            >>> pyd.step_through_windows
-            [(0, 3), (2, 5), (3, 6), (0, 3), (2, 5), (4, 7), (5, 8), (0, 3), (0, 3)]
+            >>> pyd.step_through_meas_ends is None
+            True
             >>> pyd._windows_per_subject
             {239684: 3, 1195293: 4, 68729: 1, 814703: 1}
 
-            Per-sample output carries the window count when the config flag is set, and the
-            `dynamic` payload at `pyd[idx]` is already the sliced window — no further random
-            subsampling is performed:
+            Per-sample output is the window and carries the per-subject window count when
+            the config flag is set. Sample 0 is subject 239684's first window — three events
+            starting at event 0 (note that the subject's static event has been prepended
+            into the code vocabulary as event ``5`` during preprocessing):
 
             >>> sample = pyd[0]
             >>> sample["n_subject_windows"]
@@ -277,61 +299,105 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
                    [ 1, 10, 11],
                    [10, 11,  0]], dtype=uint8)
 
-            Collated batches surface `n_subject_windows` as a parallel tensor of shape
-            `[batch_size]`, intended for per-sample loss reweighting
-            (`1 / n_subject_windows` — subjects expanded into more windows are proportionally
-            downweighted to undo the sampling bias):
+            Collated batches surface `n_subject_windows` as a `[batch_size]` tensor — use
+            `1 / n_subject_windows` as a per-sample loss weight to undo oversampling:
 
             >>> batch = pyd.collate([pyd[0], pyd[1], pyd[7]])
             >>> batch.n_subject_windows
             tensor([3, 3, 1])
-            >>> (1.0 / batch.n_subject_windows.float()).tolist()
-            [0.3333333432674408, 0.3333333432674408, 1.0]
+
+            Example 2 — SM mode, measurement-level walk that crosses event boundaries:
+
+            SM mode interprets `max_seq_len` and stride as **measurements**, not events.
+            With `max_seq_len=5, step_through_stride=3`, subject 239684 (which has 6 events
+            flattening to a total of 11 measurements) produces three windows, each exactly
+            5 measurements wide: the first ends at measurement 5, the second at 8, the
+            third at the tail (11). The index stores the smallest event index whose prefix
+            contains each measurement-level end (used by `load_subject_data`), and
+            `self.step_through_meas_ends` stores the actual measurement-level ends that get
+            passed through `process_dynamic_data.explicit_end` at sample time:
+
+            >>> sm_cfg = dataclasses.replace(
+            ...     sample_dataset_config,
+            ...     max_seq_len=5,
+            ...     seq_sampling_strategy="step_through",
+            ...     step_through_stride=3,
+            ...     batch_mode="SM",
+            ...     static_inclusion_mode="omit",
+            ... )
+            >>> sm_pyd = MEDSPytorchDataset(sm_cfg, split="train")
+            >>> [entry for entry in sm_pyd.index if entry[0] == 239684]
+            [(239684, 3), (239684, 4), (239684, 6)]
+            >>> [
+            ...     meas_end for (subj, _), meas_end in
+            ...     zip(sm_pyd.index, sm_pyd.step_through_meas_ends, strict=True)
+            ...     if subj == 239684
+            ... ]
+            [5, 8, 11]
+
+            **The critical Design B property** — the second window (measurement end 8)
+            begins *in the middle of event 2* (events [0:1] contain 1+1=2 measurements,
+            event 2 begins at measurement position 2 and contains 3 measurements, so
+            measurement 3 is inside event 2). The window is exactly 5 measurements wide
+            regardless of where event boundaries fall:
+
+            >>> sm_pyd[1]["dynamic"].to_dense()["code"]
+            array([11, 10, 11, 10, 11], dtype=uint8)
+            >>> len(sm_pyd[1]["dynamic"])
+            5
+
+            And the third window (measurement end 11) is the subject's tail — also exactly
+            5 measurements wide:
+
+            >>> sm_pyd[2]["dynamic"].to_dense()["code"]
+            array([10, 11, 10, 11,  4], dtype=uint8)
+            >>> len(sm_pyd[2]["dynamic"])
+            5
         """
 
-        stride = self.config.step_through_stride
+        # 1. Compute the stride (possibly per-subject).
+        # 2. Walk window ends.
+        # 3. Validate stride <= effective_window per subject.
+        # 4. Emit the expanded index and (for SM) the parallel measurement-end list.
+
         n_subjects_before = len(self.index)
 
         expanded_index: list[tuple[int, int]] = []
-        expanded_windows: list[tuple[int, int]] = []
+        expanded_meas_ends: list[int] = []
         windows_per_subject: dict[int, int] = {}
 
         for subject_id, end_idx in self.index:
-            seq_len = self._step_through_seq_len_for(subject_id, end_idx)
-            window = self._effective_max_seq_len_for(subject_id)
-
-            if window <= 0:
+            effective_window = self._effective_max_seq_len_for(subject_id)
+            if effective_window <= 0:
                 raise ValueError(
-                    f"Effective dynamic window size for subject {subject_id} is {window} "
-                    f"(max_seq_len={self.config.max_seq_len} minus the static elements that "
-                    "will be prepended in PREPEND mode). Increase max_seq_len so at least one "
-                    "dynamic element fits after prepending static data."
+                    f"Effective dynamic window size for subject {subject_id} is "
+                    f"{effective_window} (max_seq_len={self.config.max_seq_len} minus the "
+                    "static elements that will be prepended in PREPEND mode). Increase "
+                    "max_seq_len so at least one dynamic element fits after prepending "
+                    "static data."
                 )
 
-            if seq_len <= window:
-                expanded_index.append((subject_id, end_idx))
-                expanded_windows.append((0, seq_len))
-                windows_per_subject[subject_id] = 1
-                continue
+            stride = self._resolve_step_through_stride_for(subject_id, effective_window)
+            if stride > effective_window:
+                raise ValueError(
+                    f"step_through stride ({stride}) exceeds the effective window width "
+                    f"({effective_window}) for subject {subject_id}, which would leave gaps "
+                    "in coverage. Either reduce step_through_stride or switch to "
+                    "step_through_overlap (which is relative to the effective window and "
+                    "cannot produce gaps)."
+                )
 
-            # First window starts at 0 and we step forward by `stride`; we stop once the next
-            # window would run past the end. The final window is explicitly anchored to
-            # `seq_len - window` so the last element is always covered regardless of stride.
-            starts: list[int] = []
-            st = 0
-            while st + window < seq_len:
-                starts.append(st)
-                st += stride
-            starts.append(seq_len - window)
-            # If the previous-to-last window already covers the end exactly, drop the explicit
-            # tail anchor to avoid emitting a duplicate window.
-            if len(starts) >= 2 and starts[-1] == starts[-2]:
-                starts.pop()
-
-            windows_per_subject[subject_id] = len(starts)
-            for window_st in starts:
-                expanded_index.append((subject_id, end_idx))
-                expanded_windows.append((window_st, window_st + window))
+            if self.config.batch_mode == BatchMode.SEM:
+                ends = self._step_through_event_ends_sem(end_idx, stride, effective_window)
+                windows_per_subject[subject_id] = len(ends)
+                for end in ends:
+                    expanded_index.append((subject_id, end))
+            else:  # SM mode
+                meas_ends, event_ends = self._step_through_ends_sm(subject_id, stride, effective_window)
+                windows_per_subject[subject_id] = len(meas_ends)
+                for event_end, meas_end in zip(event_ends, meas_ends, strict=True):
+                    expanded_index.append((subject_id, event_end))
+                    expanded_meas_ends.append(meas_end)
 
         # Step-through is not allowed in task mode (the config enforces TO_END when a task is
         # set) because labels correspond to specific end-of-window predictions that can't be
@@ -345,30 +411,97 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
             )
 
         self.index = expanded_index
-        self.step_through_windows = expanded_windows
         self._windows_per_subject = windows_per_subject
+        self.step_through_meas_ends = expanded_meas_ends if self.config.batch_mode == BatchMode.SM else None
 
         # Oversampling warning — emitted after the expansion loop so the numbers we report
-        # are the actual observed stats rather than a closed-form guess. In PREPEND mode the
-        # effective dynamic window is `max_seq_len - n_static_seq_els` (and in SM+PREPEND that
-        # varies per subject), so the old closed-form formula in terms of `max_seq_len` was
-        # not the formula the expansion actually used.
+        # are the actual observed stats rather than a closed-form guess.
         n_elements = len(expanded_index)
         max_windows = max(windows_per_subject.values()) if windows_per_subject else 0
         mean_windows = n_elements / n_subjects_before if n_subjects_before else 0.0
         logger.warning(
-            "STEP_THROUGH sampling expanded %d subjects into %d dataset elements (stride=%d, "
-            "mean windows per subject=%.1f, max windows per subject=%d). Subjects with "
+            "STEP_THROUGH sampling expanded %d subjects into %d dataset elements "
+            "(mean windows per subject=%.1f, max windows per subject=%d). Subjects with "
             "longer dynamic sequences are oversampled relative to shorter ones by a factor "
             "equal to their per-subject window count. To undo the oversampling at loss time, "
             "set MEDSTorchDataConfig.include_subject_window_counts_in_batch=True and use "
             "`1 / batch.n_subject_windows` as a per-sample loss weight.",
             n_subjects_before,
             n_elements,
-            stride,
             mean_windows,
             max_windows,
         )
+
+    def _resolve_step_through_stride_for(self, subject_id: int, effective_window: int) -> int:
+        """Return the step-through stride (same unit as `max_seq_len`) for a given subject.
+
+        When `config.step_through_stride` is set directly, that value is used as-is. When
+        `config.step_through_overlap` is set instead, the stride is computed relative to the
+        per-subject effective window so that consecutive windows share exactly the requested
+        overlap regardless of how `PREPEND` shrinks the window for that subject.
+        """
+
+        if self.config.step_through_stride is not None:
+            return self.config.step_through_stride
+        return effective_window - self.config.step_through_overlap
+
+    @staticmethod
+    def _step_through_event_ends_sem(end_idx: int, stride: int, effective_window: int) -> list[int]:
+        """Return the list of event-level window ends for a SEM-mode step-through walk.
+
+        The first window ends at `effective_window` (so it contains `effective_window`
+        events); subsequent windows each shift forward by `stride` events; the final window
+        is anchored to `end_idx` so the last event is always covered regardless of stride.
+        """
+
+        if end_idx <= effective_window:
+            return [end_idx]
+        ends = list(range(effective_window, end_idx, stride))
+        if not ends or ends[-1] != end_idx:
+            ends.append(end_idx)
+        return ends
+
+    def _step_through_ends_sm(
+        self, subject_id: int, stride: int, effective_window: int
+    ) -> tuple[list[int], list[int]]:
+        """Return measurement- and event-level window ends for an SM-mode step-through walk.
+
+        Walks the measurement-level window ends `[effective_window, effective_window+stride,
+        ..., total_meas]` using the per-subject `measurements_per_event` list from the
+        schema. Each measurement-level end is converted to the smallest event index whose
+        prefix contains it via `np.searchsorted` on the cumulative-measurement array — that
+        becomes the `end` the loader reads from `self.index`, while the measurement-level
+        end is returned separately for `self.step_through_meas_ends`.
+        """
+
+        import numpy as np  # local import to avoid touching the module-level import list
+
+        shard, subject_idx = self.subj_locations[subject_id]
+        schema_row = self.schema_dfs_by_shard[shard][subject_idx]
+        if "measurements_per_event" not in schema_row.columns:
+            raise ValueError(
+                "STEP_THROUGH sampling in SM mode requires the `measurements_per_event` "
+                "column on the schema parquet, which older tensorized cohorts do not have. "
+                "Re-run preprocessing (`MTD_preprocess`) to produce it."
+            )
+        meas_per_event_series = schema_row["measurements_per_event"].item()
+        if meas_per_event_series is None:
+            # Subject with no dynamic data — single trivial window.
+            return [0], [0]
+        meas_per_event = meas_per_event_series.to_list()
+        cum_meas = np.cumsum([0, *meas_per_event])
+        total_meas = int(cum_meas[-1])
+
+        if total_meas <= effective_window:
+            # Subject is shorter than one window — emit a single entry covering everything.
+            return [total_meas], [len(meas_per_event)]
+
+        meas_ends = list(range(effective_window, total_meas, stride))
+        if not meas_ends or meas_ends[-1] != total_meas:
+            meas_ends.append(total_meas)
+
+        event_ends = np.searchsorted(cum_meas, meas_ends, side="left").tolist()
+        return meas_ends, [int(e) for e in event_ends]
 
     def _effective_max_seq_len_for(self, subject_id: int) -> int:
         """Return the dynamic-window size a step-through sample can reserve for this subject.
@@ -390,19 +523,6 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
         static_code_list = self.schema_dfs_by_shard[shard][subject_idx]["static_code"].item()
         n_static = len(static_code_list) if static_code_list is not None else 0
         return max_seq_len - n_static
-
-    def _step_through_seq_len_for(self, subject_id: int, end_idx: int) -> int:
-        """Return the per-subject sequence length in the units used by `process_dynamic_data`.
-
-        In SEM mode this is just the event count (`end_idx`). In SM mode the dynamic tensor is
-        flattened before subsampling, so we have to load the subject's data once to compute
-        the post-flatten measurement count.
-        """
-
-        if self.config.batch_mode == BatchMode.SEM:
-            return int(end_idx)
-        dyn, _ = self.load_subject_data(subject_id=subject_id, st=0, end=end_idx)
-        return len(dyn.flatten())
 
     @property
     def labels_df(self) -> pl.DataFrame:
@@ -649,21 +769,19 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
                 n_static_seq_els = len(static_data.code) if self.config.batch_mode == BatchMode.SM else 1
                 out = {"n_static_seq_els": n_static_seq_els}
 
-        if self.step_through_windows is None:
-            dynamic_data = self.config.process_dynamic_data(
-                dynamic_data, n_static_seq_els=n_static_seq_els, rng=seed
-            )
-        else:
-            # STEP_THROUGH pre-computes the slice bounds at `__init__` time (in events for
-            # SEM and post-flatten measurements for SM), so here we just do the mode-matching
-            # flatten and take the stored slice directly. Skipping `process_dynamic_data`
-            # avoids re-running its sampler for a window whose position is already decided.
-            # The slice width already reflects any `PREPEND` static-element reduction because
-            # the expansion logic uses `_effective_max_seq_len_for(subject_id)`.
-            if self.config.batch_mode == BatchMode.SM:
-                dynamic_data = dynamic_data.flatten()
-            slice_st, slice_end = self.step_through_windows[idx]
-            dynamic_data = dynamic_data[slice_st:slice_end]
+        # STEP_THROUGH in SM mode pre-computes the measurement-level window end for each
+        # sample (because events are not atomic in this mode — the window can terminate
+        # mid-event). We pass that through `process_dynamic_data.explicit_end`. In every
+        # other config (including SEM step-through), the expanded index's `end_event` is
+        # all we need: `process_dynamic_data` + the `STEP_THROUGH → TO_END` delegation in
+        # `subsample_st_offset` handles the window at the event level.
+        explicit_end = self.step_through_meas_ends[idx] if self.step_through_meas_ends is not None else None
+        dynamic_data = self.config.process_dynamic_data(
+            dynamic_data,
+            n_static_seq_els=n_static_seq_els,
+            rng=seed,
+            explicit_end=explicit_end,
+        )
 
         # Only leak the per-subject window count into the sample dict when the user has
         # explicitly asked for it in the batch — otherwise the sample API would depend on

--- a/src/meds_torchdata/pytorch_dataset.py
+++ b/src/meds_torchdata/pytorch_dataset.py
@@ -207,6 +207,113 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
         )
         self.labels = self.schema_df[self.LABEL_COL] if self.has_task_labels else None
 
+        # Parallel arrays populated only when STEP_THROUGH sampling is active. For every index
+        # entry, `self.step_through_windows[i]` is a `(st, end)` tuple in "dynamic data length"
+        # units (matching `MEDSTorchDataConfig.process_dynamic_data`: events in SEM mode,
+        # post-flatten measurements in SM mode) and `self.step_through_window_counts[i]` is the
+        # total number of dataset elements the originating subject expands into (used to
+        # populate `MEDSTorchBatch.n_subject_windows` for loss reweighting).
+        self.step_through_windows: list[tuple[int, int]] | None = None
+        self.step_through_window_counts: list[int] | None = None
+        if self.config.seq_sampling_strategy == SubsequenceSamplingStrategy.STEP_THROUGH:
+            self._expand_index_for_step_through()
+
+    def _expand_index_for_step_through(self) -> None:
+        """Expand `self.index` so that STEP_THROUGH sampling produces one entry per window.
+
+        For each subject in the pre-expansion index, this walks a sliding window of size
+        `max_seq_len` across the permitted sequence with stride `step_through_stride`,
+        producing one dataset element per window. In SEM mode, window/stride are in events and
+        `seq_len = end_idx` (already known from the schema). In SM mode, the dynamic data is
+        flattened first, so we must load each subject's dynamic data once to compute the true
+        per-subject measurement count before expansion. A warning is logged about the resulting
+        oversampling of subjects with longer sequences; set
+        `config.include_subject_window_counts_in_batch=True` to surface per-sample window
+        counts in the collated batch so downstream code can reweight losses.
+        """
+
+        stride = self.config.step_through_stride
+        window = self.config.max_seq_len
+
+        expanded_index: list[tuple[int, int]] = []
+        expanded_windows: list[tuple[int, int]] = []
+        expanded_counts: list[int] = []
+
+        # Oversampling warning: the subject with the longest sequence dominates training when
+        # step-through stride is small. Surface that explicitly before doing the heavy work.
+        logger.warning(
+            "STEP_THROUGH sampling expands each subject into ceil(max(0, seq_len - "
+            "max_seq_len) / stride) + 1 dataset elements, which means subjects with longer "
+            "sequences are oversampled relative to shorter ones. To undo the oversampling at "
+            "loss time, set MEDSTorchDataConfig.include_subject_window_counts_in_batch=True "
+            "and use `1 / batch.n_subject_windows` as a per-sample loss weight."
+        )
+
+        for subject_id, end_idx in self.index:
+            seq_len = self._step_through_seq_len_for(subject_id, end_idx)
+
+            if seq_len <= window:
+                expanded_index.append((subject_id, end_idx))
+                expanded_windows.append((0, seq_len))
+                expanded_counts.append(1)
+                continue
+
+            # First window starts at 0 and we step forward by `stride`; we stop once the next
+            # window would run past the end. The final window is explicitly anchored to
+            # `seq_len - window` so the last element is always covered regardless of stride.
+            starts: list[int] = []
+            st = 0
+            while st + window < seq_len:
+                starts.append(st)
+                st += stride
+            starts.append(seq_len - window)
+            # If the previous-to-last window already covers the end exactly, drop the explicit
+            # tail anchor to avoid emitting a duplicate window.
+            if len(starts) >= 2 and starts[-1] == starts[-2]:
+                starts.pop()
+
+            n_windows = len(starts)
+            for window_st in starts:
+                expanded_index.append((subject_id, end_idx))
+                expanded_windows.append((window_st, window_st + window))
+                expanded_counts.append(n_windows)
+
+        # Rebuild labels in the same (expanded) order. Step-through is not allowed in task mode
+        # (the config enforces TO_END when a task is set), so there should be no labels to
+        # duplicate, but we still assert this here to make the invariant explicit.
+        if self.has_task_labels:  # pragma: no cover -- prevented by MEDSTorchDataConfig validation
+            raise ValueError(
+                "STEP_THROUGH sampling is not compatible with task-mode datasets; labels "
+                "correspond to specific end-of-window predictions and cannot be mapped onto "
+                "arbitrarily-placed mid-sequence windows."
+            )
+
+        self.index = expanded_index
+        self.step_through_windows = expanded_windows
+        self.step_through_window_counts = expanded_counts
+        logger.info(
+            "STEP_THROUGH expanded %d subjects into %d dataset elements (stride=%d, "
+            "max_seq_len=%d, max windows per subject=%d).",
+            len({s for s, _ in expanded_index}),
+            len(expanded_index),
+            stride,
+            window,
+            max(expanded_counts) if expanded_counts else 0,
+        )
+
+    def _step_through_seq_len_for(self, subject_id: int, end_idx: int) -> int:
+        """Return the per-subject sequence length in the units used by `process_dynamic_data`.
+
+        In SEM mode this is just the event count (`end_idx`). In SM mode the dynamic tensor is
+        flattened before subsampling, so we have to load the subject's data once to compute
+        the post-flatten measurement count.
+        """
+
+        if self.config.batch_mode == BatchMode.SEM:
+            return int(end_idx)
+        dyn, _ = self.load_subject_data(subject_id=subject_id, st=0, end=end_idx)
+        return len(dyn.flatten())
+
     @property
     def labels_df(self) -> pl.DataFrame:
         """Returns the task labels as a DataFrame, in the MEDS Label schema, or `None` if there is no task.
@@ -445,9 +552,17 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
                 n_static_seq_els = len(static_data.code) if self.config.batch_mode == BatchMode.SM else 1
                 out = {"n_static_seq_els": n_static_seq_els}
 
+        explicit_window = self.step_through_windows[idx] if self.step_through_windows is not None else None
+
         dynamic_data = self.config.process_dynamic_data(
-            dynamic_data, n_static_seq_els=n_static_seq_els, rng=seed
+            dynamic_data,
+            n_static_seq_els=n_static_seq_els,
+            rng=seed,
+            explicit_window=explicit_window,
         )
+
+        if self.step_through_window_counts is not None:
+            out["n_subject_windows"] = self.step_through_window_counts[idx]
 
         if self.config.static_inclusion_mode == StaticInclusionMode.PREPEND:
             static_as_JNRT = static_data.to_JNRT(self.config.batch_mode, dynamic_data.schema)
@@ -1091,6 +1206,13 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
 
         if self.has_task_labels:
             out[self.LABEL_COL] = torch.Tensor([item[self.LABEL_COL] for item in batch]).bool()
+
+        if self.config.include_subject_window_counts_in_batch:
+            # For non-step-through datasets every sample corresponds to one window, so the
+            # count is simply 1 for every row — still expose it so downstream loss code can
+            # treat the field uniformly regardless of sampling mode.
+            counts = [item.get("n_subject_windows", 1) for item in batch]
+            out["n_subject_windows"] = torch.as_tensor(counts, dtype=torch.long)
 
         return MEDSTorchBatch(**out)
 

--- a/src/meds_torchdata/pytorch_dataset.py
+++ b/src/meds_torchdata/pytorch_dataset.py
@@ -194,15 +194,32 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
             "static_code",
             "static_numeric_value",
         ]
-        if (
+        needs_meas_per_event = (
             self.config.seq_sampling_strategy == SubsequenceSamplingStrategy.STEP_THROUGH
             and self.config.batch_mode == BatchMode.SM
-        ):
+        )
+        if needs_meas_per_event:
             needed_schema_cols.append("measurements_per_event")
 
         for shard, schema_fp in self.config.schema_fps:
             if not shard.startswith(f"{self.split}/"):
                 continue
+
+            # Inspect the parquet schema first so that older tensorized cohorts missing the
+            # `measurements_per_event` column (added when STEP_THROUGH SM mode landed) fail
+            # with a clear "re-run preprocessing" error instead of a low-level polars /
+            # pyarrow column-not-found traceback. Only the column *we asked for* matters,
+            # so we only check when the user's config actually needs it.
+            if needs_meas_per_event:
+                available = set(pq.read_schema(schema_fp).names)
+                if "measurements_per_event" not in available:
+                    raise ValueError(
+                        f"STEP_THROUGH sampling in SM mode requires the "
+                        f"`measurements_per_event` column on the schema parquet at "
+                        f"{schema_fp}, which older tensorized cohorts (preprocessed before "
+                        "this feature landed) do not have. Re-run preprocessing "
+                        "(`MTD_preprocess`) to produce it."
+                    )
 
             df = pl.read_parquet(schema_fp, columns=needed_schema_cols, use_pyarrow=True).with_columns(
                 pl.col("static_code").list.eval(pl.element().fill_null(0)),
@@ -575,14 +592,12 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
             ([11], [6])
         """
 
+        # `__init__` has already verified that `measurements_per_event` exists on every
+        # schema parquet this dataset reads (the check lives there so we can raise a clean
+        # "re-run preprocessing" error before the eager `pl.read_parquet(columns=...)`
+        # would otherwise blow up with a low-level parquet/column-not-found traceback).
         shard, subject_idx = self.subj_locations[subject_id]
         schema_row = self.schema_dfs_by_shard[shard][subject_idx]
-        if "measurements_per_event" not in schema_row.columns:
-            raise ValueError(
-                "STEP_THROUGH sampling in SM mode requires the `measurements_per_event` "
-                "column on the schema parquet, which older tensorized cohorts do not have. "
-                "Re-run preprocessing (`MTD_preprocess`) to produce it."
-            )
         meas_per_event_series = schema_row["measurements_per_event"].item()
         if meas_per_event_series is None:
             # Subject with no dynamic data — single trivial window.

--- a/src/meds_torchdata/pytorch_dataset.py
+++ b/src/meds_torchdata/pytorch_dataset.py
@@ -182,11 +182,29 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
         self.schema_dfs_by_shard: dict[str, pl.DataFrame] = {}
         self.subj_locations: dict[int, tuple[str, int]] = {}
 
+        # Only read the columns this dataset actually needs. Parquet is columnar so this is
+        # a per-column I/O saving at subject-schema load time — most importantly, the
+        # `measurements_per_event` list column is only needed by STEP_THROUGH sampling in
+        # SM mode (where the expansion uses it to map measurement-level window ends back
+        # to event-level indices), so every other config skips it. `start_time` is emitted
+        # by preprocessing but never consumed downstream, so it's always skipped.
+        needed_schema_cols = [
+            DataSchema.subject_id_name,
+            DataSchema.time_name,
+            "static_code",
+            "static_numeric_value",
+        ]
+        if (
+            self.config.seq_sampling_strategy == SubsequenceSamplingStrategy.STEP_THROUGH
+            and self.config.batch_mode == BatchMode.SM
+        ):
+            needed_schema_cols.append("measurements_per_event")
+
         for shard, schema_fp in self.config.schema_fps:
             if not shard.startswith(f"{self.split}/"):
                 continue
 
-            df = pl.read_parquet(schema_fp, use_pyarrow=True).with_columns(
+            df = pl.read_parquet(schema_fp, columns=needed_schema_cols, use_pyarrow=True).with_columns(
                 pl.col("static_code").list.eval(pl.element().fill_null(0)),
                 pl.col("static_numeric_value").list.eval(pl.element().fill_null(np.nan)),
             )

--- a/src/meds_torchdata/pytorch_dataset.py
+++ b/src/meds_torchdata/pytorch_dataset.py
@@ -230,10 +230,16 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
         oversampling of subjects with longer sequences; set
         `config.include_subject_window_counts_in_batch=True` to surface per-sample window
         counts in the collated batch so downstream code can reweight losses.
+
+        When `static_inclusion_mode=PREPEND`, the effective window size is reduced by the
+        number of static sequence elements that will be prepended (1 event in SEM mode, or
+        `len(static_code)` measurements per subject in SM mode) so that the concatenated
+        [static; dynamic] sample still fits inside `config.max_seq_len`. This is the same
+        reduction applied by `MEDSTorchDataConfig.process_dynamic_data` for the other
+        sampling strategies.
         """
 
         stride = self.config.step_through_stride
-        window = self.config.max_seq_len
 
         expanded_index: list[tuple[int, int]] = []
         expanded_windows: list[tuple[int, int]] = []
@@ -251,6 +257,15 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
 
         for subject_id, end_idx in self.index:
             seq_len = self._step_through_seq_len_for(subject_id, end_idx)
+            window = self._effective_max_seq_len_for(subject_id)
+
+            if window <= 0:
+                raise ValueError(
+                    f"Effective dynamic window size for subject {subject_id} is {window} "
+                    f"(max_seq_len={self.config.max_seq_len} minus the static elements that "
+                    "will be prepended in PREPEND mode). Increase max_seq_len so at least one "
+                    "dynamic element fits after prepending static data."
+                )
 
             if seq_len <= window:
                 expanded_index.append((subject_id, end_idx))
@@ -297,9 +312,30 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
             len({s for s, _ in expanded_index}),
             len(expanded_index),
             stride,
-            window,
+            self.config.max_seq_len,
             max(expanded_counts) if expanded_counts else 0,
         )
+
+    def _effective_max_seq_len_for(self, subject_id: int) -> int:
+        """Return the dynamic-window size a step-through sample can reserve for this subject.
+
+        This mirrors the `max_seq_len -= n_static_seq_els` adjustment inside
+        `MEDSTorchDataConfig.process_dynamic_data` for PREPEND mode — so that the resulting
+        `[static; dynamic]` sample after prepending still has length `<= config.max_seq_len`.
+        For every other static inclusion mode this just returns `config.max_seq_len`.
+        """
+
+        max_seq_len = self.config.max_seq_len
+        if self.config.static_inclusion_mode != StaticInclusionMode.PREPEND:
+            return max_seq_len
+        if self.config.batch_mode == BatchMode.SEM:
+            return max_seq_len - 1
+        # SM + PREPEND: the number of reserved slots is the per-subject static measurement
+        # count, read from the schema df without loading the dynamic tensors.
+        shard, subject_idx = self.subj_locations[subject_id]
+        static_code_list = self.schema_dfs_by_shard[shard][subject_idx]["static_code"].item()
+        n_static = len(static_code_list) if static_code_list is not None else 0
+        return max_seq_len - n_static
 
     def _step_through_seq_len_for(self, subject_id: int, end_idx: int) -> int:
         """Return the per-subject sequence length in the units used by `process_dynamic_data`.

--- a/src/meds_torchdata/pytorch_dataset.py
+++ b/src/meds_torchdata/pytorch_dataset.py
@@ -626,7 +626,12 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
             explicit_window=explicit_window,
         )
 
-        if self.step_through_window_counts is not None:
+        # Only leak the per-subject window count into the sample dict when the user has
+        # explicitly asked for it in the batch — otherwise the sample API would depend on
+        # the sampling strategy, which a user reading individual `dataset[idx]` outputs
+        # would find surprising. The collator's fallback-to-1 handles non-step-through
+        # datasets that still opt into the batch field.
+        if self.config.include_subject_window_counts_in_batch and self.step_through_window_counts is not None:
             out["n_subject_windows"] = self.step_through_window_counts[idx]
 
         if self.config.static_inclusion_mode == StaticInclusionMode.PREPEND:

--- a/src/meds_torchdata/pytorch_dataset.py
+++ b/src/meds_torchdata/pytorch_dataset.py
@@ -207,14 +207,15 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
         )
         self.labels = self.schema_df[self.LABEL_COL] if self.has_task_labels else None
 
-        # Parallel arrays populated only when STEP_THROUGH sampling is active. For every index
-        # entry, `self.step_through_windows[i]` is a `(st, end)` tuple in "dynamic data length"
-        # units (matching `MEDSTorchDataConfig.process_dynamic_data`: events in SEM mode,
-        # post-flatten measurements in SM mode) and `self.step_through_window_counts[i]` is the
-        # total number of dataset elements the originating subject expands into (used to
-        # populate `MEDSTorchBatch.n_subject_windows` for loss reweighting).
+        # Populated only when STEP_THROUGH sampling is active. For every index entry,
+        # `self.step_through_windows[i]` is a `(st, end)` slice applied to the dynamic data
+        # after the optional SM-mode flatten (so `st`, `end` are in events in SEM mode and in
+        # post-flatten measurements in SM mode). The number of dataset elements each subject
+        # expands into is cached as a simple `subject_id -> count` dict, which populates
+        # `MEDSTorchBatch.n_subject_windows` when
+        # `config.include_subject_window_counts_in_batch` is set.
         self.step_through_windows: list[tuple[int, int]] | None = None
-        self.step_through_window_counts: list[int] | None = None
+        self._windows_per_subject: dict[int, int] | None = None
         if self.config.seq_sampling_strategy == SubsequenceSamplingStrategy.STEP_THROUGH:
             self._expand_index_for_step_through()
 
@@ -237,6 +238,55 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
         [static; dynamic] sample still fits inside `config.max_seq_len`. This is the same
         reduction applied by `MEDSTorchDataConfig.process_dynamic_data` for the other
         sampling strategies.
+
+        Examples:
+            >>> import dataclasses
+            >>> cfg = dataclasses.replace(
+            ...     sample_dataset_config,
+            ...     max_seq_len=3,
+            ...     seq_sampling_strategy="step_through",
+            ...     step_through_stride=2,
+            ...     batch_mode="SEM",
+            ...     static_inclusion_mode="omit",
+            ...     include_subject_window_counts_in_batch=True,
+            ... )
+
+            `MEDSPytorchDataset.__init__` runs the expansion automatically. The four subjects
+            in the fixture have event counts of 6, 8, 3, and 3, so with window=3 and stride=2
+            the long subjects expand into multiple entries while the short ones contribute a
+            single window each:
+
+            >>> pyd = MEDSPytorchDataset(cfg, split="train")
+            >>> pyd.index
+            [(239684, 6), (239684, 6), (239684, 6), (1195293, 8), (1195293, 8), (1195293, 8),
+             (1195293, 8), (68729, 3), (814703, 3)]
+            >>> pyd.step_through_windows
+            [(0, 3), (2, 5), (3, 6), (0, 3), (2, 5), (4, 7), (5, 8), (0, 3), (0, 3)]
+            >>> pyd._windows_per_subject
+            {239684: 3, 1195293: 4, 68729: 1, 814703: 1}
+
+            Per-sample output carries the window count when the config flag is set, and the
+            `dynamic` payload at `pyd[idx]` is already the sliced window — no further random
+            subsampling is performed:
+
+            >>> sample = pyd[0]
+            >>> sample["n_subject_windows"]
+            3
+            >>> sample["dynamic"].to_dense()["code"]
+            array([[ 5,  0,  0],
+                   [ 1, 10, 11],
+                   [10, 11,  0]], dtype=uint8)
+
+            Collated batches surface `n_subject_windows` as a parallel tensor of shape
+            `[batch_size]`, intended for per-sample loss reweighting
+            (`1 / n_subject_windows` — subjects expanded into more windows are proportionally
+            downweighted to undo the sampling bias):
+
+            >>> batch = pyd.collate([pyd[0], pyd[1], pyd[7]])
+            >>> batch.n_subject_windows
+            tensor([3, 3, 1])
+            >>> (1.0 / batch.n_subject_windows.float()).tolist()
+            [0.3333333432674408, 0.3333333432674408, 1.0]
         """
 
         stride = self.config.step_through_stride
@@ -244,7 +294,7 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
 
         expanded_index: list[tuple[int, int]] = []
         expanded_windows: list[tuple[int, int]] = []
-        expanded_counts: list[int] = []
+        windows_per_subject: dict[int, int] = {}
 
         for subject_id, end_idx in self.index:
             seq_len = self._step_through_seq_len_for(subject_id, end_idx)
@@ -261,7 +311,7 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
             if seq_len <= window:
                 expanded_index.append((subject_id, end_idx))
                 expanded_windows.append((0, seq_len))
-                expanded_counts.append(1)
+                windows_per_subject[subject_id] = 1
                 continue
 
             # First window starts at 0 and we step forward by `stride`; we stop once the next
@@ -278,15 +328,15 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
             if len(starts) >= 2 and starts[-1] == starts[-2]:
                 starts.pop()
 
-            n_windows = len(starts)
+            windows_per_subject[subject_id] = len(starts)
             for window_st in starts:
                 expanded_index.append((subject_id, end_idx))
                 expanded_windows.append((window_st, window_st + window))
-                expanded_counts.append(n_windows)
 
-        # Rebuild labels in the same (expanded) order. Step-through is not allowed in task mode
-        # (the config enforces TO_END when a task is set), so there should be no labels to
-        # duplicate, but we still assert this here to make the invariant explicit.
+        # Step-through is not allowed in task mode (the config enforces TO_END when a task is
+        # set) because labels correspond to specific end-of-window predictions that can't be
+        # remapped onto arbitrarily-placed mid-sequence windows. The check here makes the
+        # invariant explicit.
         if self.has_task_labels:  # pragma: no cover -- prevented by MEDSTorchDataConfig validation
             raise ValueError(
                 "STEP_THROUGH sampling is not compatible with task-mode datasets; labels "
@@ -296,7 +346,7 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
 
         self.index = expanded_index
         self.step_through_windows = expanded_windows
-        self.step_through_window_counts = expanded_counts
+        self._windows_per_subject = windows_per_subject
 
         # Oversampling warning — emitted after the expansion loop so the numbers we report
         # are the actual observed stats rather than a closed-form guess. In PREPEND mode the
@@ -304,7 +354,7 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
         # varies per subject), so the old closed-form formula in terms of `max_seq_len` was
         # not the formula the expansion actually used.
         n_elements = len(expanded_index)
-        max_windows = max(expanded_counts) if expanded_counts else 0
+        max_windows = max(windows_per_subject.values()) if windows_per_subject else 0
         mean_windows = n_elements / n_subjects_before if n_subjects_before else 0.0
         logger.warning(
             "STEP_THROUGH sampling expanded %d subjects into %d dataset elements (stride=%d, "
@@ -583,27 +633,7 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
         """
 
         subject_id, end_idx = self.index[idx]
-
-        # In SEM + step-through, the stored `(window_st, window_end)` is already in event
-        # units, so we can load only that event slice instead of reading the full `[0,
-        # end_idx)` prefix for every window of the same subject. This turns an `O(N *
-        # end_idx)` total read (for N windows per subject) into `O(N * window_size)`.
-        # In SM mode the window is in post-flatten measurement units, which can't be mapped
-        # back to an event range without loading the full prefix first, so step-through SM
-        # keeps the prefix-load path.
-        explicit_window: tuple[int, int] | None = None
-        if self.step_through_windows is not None and self.config.batch_mode == BatchMode.SEM:
-            window_st, window_end = self.step_through_windows[idx]
-            dynamic_data, static_data = self.load_subject_data(
-                subject_id=subject_id, st=window_st, end=window_end
-            )
-            # The loaded slice already *is* the window; tell `process_dynamic_data` to
-            # consume all of it (rebased to 0).
-            explicit_window = (0, window_end - window_st)
-        else:
-            dynamic_data, static_data = self.load_subject_data(subject_id=subject_id, st=0, end=end_idx)
-            if self.step_through_windows is not None:
-                explicit_window = self.step_through_windows[idx]
+        dynamic_data, static_data = self.load_subject_data(subject_id=subject_id, st=0, end=end_idx)
 
         match self.config.static_inclusion_mode:
             case StaticInclusionMode.OMIT:
@@ -619,20 +649,29 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
                 n_static_seq_els = len(static_data.code) if self.config.batch_mode == BatchMode.SM else 1
                 out = {"n_static_seq_els": n_static_seq_els}
 
-        dynamic_data = self.config.process_dynamic_data(
-            dynamic_data,
-            n_static_seq_els=n_static_seq_els,
-            rng=seed,
-            explicit_window=explicit_window,
-        )
+        if self.step_through_windows is None:
+            dynamic_data = self.config.process_dynamic_data(
+                dynamic_data, n_static_seq_els=n_static_seq_els, rng=seed
+            )
+        else:
+            # STEP_THROUGH pre-computes the slice bounds at `__init__` time (in events for
+            # SEM and post-flatten measurements for SM), so here we just do the mode-matching
+            # flatten and take the stored slice directly. Skipping `process_dynamic_data`
+            # avoids re-running its sampler for a window whose position is already decided.
+            # The slice width already reflects any `PREPEND` static-element reduction because
+            # the expansion logic uses `_effective_max_seq_len_for(subject_id)`.
+            if self.config.batch_mode == BatchMode.SM:
+                dynamic_data = dynamic_data.flatten()
+            slice_st, slice_end = self.step_through_windows[idx]
+            dynamic_data = dynamic_data[slice_st:slice_end]
 
         # Only leak the per-subject window count into the sample dict when the user has
         # explicitly asked for it in the batch — otherwise the sample API would depend on
         # the sampling strategy, which a user reading individual `dataset[idx]` outputs
         # would find surprising. The collator's fallback-to-1 handles non-step-through
         # datasets that still opt into the batch field.
-        if self.config.include_subject_window_counts_in_batch and self.step_through_window_counts is not None:
-            out["n_subject_windows"] = self.step_through_window_counts[idx]
+        if self.config.include_subject_window_counts_in_batch and self._windows_per_subject is not None:
+            out["n_subject_windows"] = self._windows_per_subject[subject_id]
 
         if self.config.static_inclusion_mode == StaticInclusionMode.PREPEND:
             static_as_JNRT = static_data.to_JNRT(self.config.batch_mode, dynamic_data.schema)

--- a/src/meds_torchdata/types.py
+++ b/src/meds_torchdata/types.py
@@ -65,6 +65,17 @@ class SubsequenceSamplingStrategy(StrEnum):
             `MEDSTorchDataConfig.include_subject_window_counts_in_batch` for the
             corresponding loss-reweighting escape hatch.
 
+            Performance note for SM mode: each per-window load reads events
+            `[0, enclosing_event_end)` from disk, where `enclosing_event_end` is the smallest
+            event index whose cumulative measurement count covers the target window's
+            measurement end. If the dataset has very fat events (many measurements per
+            timestamp) and `max_seq_len` is small relative to the per-event measurement
+            count, consecutive windows can share the same enclosing event and re-read the
+            same prefix — so SM-mode step-through I/O does **not** scale purely with
+            `max_seq_len` in that regime. For cohorts with thin events (≤ a few measurements
+            per timestamp) this is a non-issue. Switching to `BatchMode.SEM` avoids the
+            re-read entirely because the window is already event-aligned.
+
     Methods:
         subsample_st_offset: Subsample starting offset based on maximum sequence length and sampling strategy.
             This method can be used on instances

--- a/src/meds_torchdata/types.py
+++ b/src/meds_torchdata/types.py
@@ -35,6 +35,13 @@ class SubsequenceSamplingStrategy(StrEnum):
         TO_END: Sample a subsequence from the end of the full sequence.
             Note this starts at the last element and moves back.
         FROM_START: Sample a subsequence from the start of the full sequence.
+        STEP_THROUGH: Deterministically walk through every permitted subsequence of the full
+            sequence in order, stepping by `MEDSTorchDataConfig.step_through_stride` elements.
+            Unlike the other strategies, this expands one subject into multiple dataset
+            elements (one per window), so `len(dataset)` grows for subjects with longer
+            sequences — the dataset logs a warning on startup about the resulting oversampling.
+            Start offsets are resolved at the dataset-expansion level, not via
+            `subsample_st_offset` (which raises `NotImplementedError` for this strategy).
 
     Methods:
         subsample_st_offset: Subsample starting offset based on maximum sequence length and sampling strategy.
@@ -46,6 +53,7 @@ class SubsequenceSamplingStrategy(StrEnum):
     RANDOM = "random"
     TO_END = "to_end"
     FROM_START = "from_start"
+    STEP_THROUGH = "step_through"
 
     def subsample_st_offset(
         self,
@@ -75,6 +83,14 @@ class SubsequenceSamplingStrategy(StrEnum):
             2
             >>> SubsequenceSamplingStrategy.RANDOM.subsample_st_offset(10, 10) is None
             True
+
+            `STEP_THROUGH` cannot be resolved via this method — it is handled at the dataset
+            level by expanding one subject into many windows — so calling it here errors:
+
+            >>> SubsequenceSamplingStrategy.STEP_THROUGH.subsample_st_offset(10, 5)
+            Traceback (most recent call last):
+                ...
+            NotImplementedError: STEP_THROUGH is resolved at the dataset-expansion level; ...
 
             The random sampler must be able to place the window flush against the end of the
             sequence (i.e. sample `st = seq_len - max_seq_len`, so that the last event at index
@@ -107,6 +123,12 @@ class SubsequenceSamplingStrategy(StrEnum):
                 return seq_len - max_seq_len
             case SubsequenceSamplingStrategy.FROM_START:
                 return 0
+            case SubsequenceSamplingStrategy.STEP_THROUGH:
+                raise NotImplementedError(
+                    "STEP_THROUGH is resolved at the dataset-expansion level; the dataset "
+                    "constructor pre-computes one (subject_id, window_start, window_end) index "
+                    "entry per window, so there is no single start offset to return here."
+                )
             case _:
                 raise ValueError(f"Invalid subsequence sampling strategy {self}!")
 
@@ -1243,6 +1265,11 @@ class MEDSTorchBatch:
     # Task label data elements (subject-level):
     boolean_value: torch.BoolTensor | None = None
 
+    # Optional oversampling weight for step-through sampling: for each sample, the number of
+    # dataset elements the originating subject expands into. Intended for per-sample loss
+    # reweighting (e.g. `loss_weight = 1 / n_subject_windows`). Shape: `[batch_size]`.
+    n_subject_windows: torch.LongTensor | None = None
+
     STATIC_TENSOR_NAMES: ClassVar[tuple[str]] = (
         "static_code",
         "static_numeric_value",
@@ -1329,6 +1356,9 @@ class MEDSTorchBatch:
 
         if self.has_labels:
             self.__check_shape("boolean_value", (self.batch_size,))
+
+        if self.n_subject_windows is not None:
+            self.__check_shape("n_subject_windows", (self.batch_size,))
 
     # Here we define some operators to make this behave like a dictionary:
     def __getitem__(self, key: str) -> torch.Tensor:

--- a/src/meds_torchdata/types.py
+++ b/src/meds_torchdata/types.py
@@ -46,12 +46,24 @@ class SubsequenceSamplingStrategy(StrEnum):
             Note this starts at the last element and moves back.
         FROM_START: Sample a subsequence from the start of the full sequence.
         STEP_THROUGH: Deterministically walk through every permitted subsequence of the full
-            sequence in order, stepping by `MEDSTorchDataConfig.step_through_stride` elements.
-            Unlike the other strategies, this expands one subject into multiple dataset
-            elements (one per window), so `len(dataset)` grows for subjects with longer
-            sequences — the dataset logs a warning on startup about the resulting oversampling.
-            Start offsets are resolved at the dataset-expansion level, not via
-            `subsample_st_offset` (which raises `NotImplementedError` for this strategy).
+            sequence in order, stepping by `MEDSTorchDataConfig.step_through_stride` (or
+            equivalently `step_through_overlap`) elements. The stride / overlap is expressed
+            in the same unit as `max_seq_len` — **events** in `BatchMode.SEM` and
+            **measurements** in `BatchMode.SM` — so windows line up with what the user
+            specified regardless of mode. Unlike the other strategies, this expands one
+            subject into multiple dataset elements (one per window), so `len(dataset)` grows
+            for subjects with longer sequences. `MEDSPytorchDataset.__init__` writes the
+            per-window end-event into `self.index` directly, and in SM mode additionally
+            records the measurement-level window end in a parallel
+            `self.step_through_meas_ends` array. `subsample_st_offset` delegates to `TO_END`
+            (take the last `max_seq_len` elements of the loaded prefix), so step-through is
+            "modify the index, run `TO_END` per entry". In SM mode, the measurement-level end
+            is passed explicitly through `MEDSTorchDataConfig.process_dynamic_data` via its
+            `explicit_end` parameter, which lets the window terminate mid-event and preserves
+            the exact measurement-level coverage the user asked for. A warning with the
+            observed expansion stats is logged on startup; see
+            `MEDSTorchDataConfig.include_subject_window_counts_in_batch` for the
+            corresponding loss-reweighting escape hatch.
 
     Methods:
         subsample_st_offset: Subsample starting offset based on maximum sequence length and sampling strategy.
@@ -95,13 +107,15 @@ class SubsequenceSamplingStrategy(StrEnum):
             >>> SubsequenceSamplingStrategy.RANDOM.subsample_st_offset(10, 10) is None
             True
 
-            `STEP_THROUGH` cannot be resolved via this method — it is handled at the dataset
-            level by expanding one subject into many windows — so calling it here errors:
+            `STEP_THROUGH` delegates to `TO_END`: each index entry already points at the
+            "load me up to this event" endpoint, so the sampler just takes the last
+            `max_seq_len` elements of the loaded prefix. `MEDSPytorchDataset.__init__`
+            inserts the extra per-window index entries before this method is ever called.
 
             >>> SubsequenceSamplingStrategy.STEP_THROUGH.subsample_st_offset(10, 5)
-            Traceback (most recent call last):
-                ...
-            NotImplementedError: STEP_THROUGH is resolved at the dataset-expansion level; ...
+            5
+            >>> SubsequenceSamplingStrategy.STEP_THROUGH.subsample_st_offset(5, 10) is None
+            True
 
             The random sampler must be able to place the window flush against the end of the
             sequence (i.e. sample `st = seq_len - max_seq_len`, so that the last event at index
@@ -153,16 +167,14 @@ class SubsequenceSamplingStrategy(StrEnum):
                 # probability of `max_seq_len / (seq_len + max_seq_len - 1)`. Callers must handle
                 # the negative/overhanging offset by clipping the slice to `[0, seq_len)`.
                 return int(resolve_rng(rng).integers(-(max_seq_len - 1), seq_len))
-            case SubsequenceSamplingStrategy.TO_END:
+            case SubsequenceSamplingStrategy.TO_END | SubsequenceSamplingStrategy.STEP_THROUGH:
+                # STEP_THROUGH is just TO_END over a modified index: the dataset constructor
+                # has already inserted one `(subject_id, window_end_event)` entry per window,
+                # so by the time this runs the loaded prefix *is* the step-through window and
+                # TO_END takes its last `max_seq_len` elements.
                 return seq_len - max_seq_len
             case SubsequenceSamplingStrategy.FROM_START:
                 return 0
-            case SubsequenceSamplingStrategy.STEP_THROUGH:
-                raise NotImplementedError(
-                    "STEP_THROUGH is resolved at the dataset-expansion level; the dataset "
-                    "constructor pre-computes one (subject_id, window_start, window_end) index "
-                    "entry per window, so there is no single start offset to return here."
-                )
             case _:
                 raise ValueError(f"Invalid subsequence sampling strategy {self}!")
 

--- a/tests/preprocessing/test_tokenization.py
+++ b/tests/preprocessing/test_tokenization.py
@@ -144,6 +144,10 @@ SCHEMAS_SCHEMA = {
     "static_numeric_value": pl.List(NORMALIZED_MEDS_SCHEMA["numeric_value"]),
     "start_time": NORMALIZED_MEDS_SCHEMA["time"],
     "time": pl.List(NORMALIZED_MEDS_SCHEMA["time"]),
+    # Parallel to `time` — number of raw measurement rows at each unique timestamp. Used
+    # by STEP_THROUGH sampling in SM mode to map measurement-level window ends back to
+    # event-level indices without re-loading the dynamic tensor.
+    "measurements_per_event": pl.List(pl.UInt32),
 }
 
 SEQ_SCHEMA = {
@@ -173,6 +177,13 @@ TRAIN_0_TIMES = [
         datetime(2010, 6, 20, 20, 50, 4),
     ],
 ]
+TRAIN_0_MEASUREMENTS_PER_EVENT = [
+    # Subject 239684: DOB (1), [1,10,11] (3), [10,11] (2), [10,11] (2), [10,11] (2), [4] (1)
+    [1, 3, 2, 2, 2, 1],
+    # Subject 1195293: DOB (1), [1,10,11] (3), then five [10,11] pairs (2 each), [4] (1)
+    [1, 3, 2, 2, 2, 2, 2, 1],
+]
+
 WANT_SCHEMAS_TRAIN_0 = pl.DataFrame(
     {
         "subject_id": [239684, 1195293],
@@ -183,6 +194,7 @@ WANT_SCHEMAS_TRAIN_0 = pl.DataFrame(
         ],
         "start_time": [ts[0] for ts in TRAIN_0_TIMES],
         "time": TRAIN_0_TIMES,
+        "measurements_per_event": TRAIN_0_MEASUREMENTS_PER_EVENT,
     },
     schema=SCHEMAS_SCHEMA,
 )
@@ -194,6 +206,7 @@ WANT_SCHEMAS_TRAIN_0_MISSING_STATIC = pl.DataFrame(
         "static_numeric_value": [None, [None, 0.06802856922149658]],
         "start_time": [ts[0] for ts in TRAIN_0_TIMES],
         "time": TRAIN_0_TIMES,
+        "measurements_per_event": TRAIN_0_MEASUREMENTS_PER_EVENT,
     },
     schema=SCHEMAS_SCHEMA,
 )
@@ -253,6 +266,8 @@ WANT_SCHEMAS_TRAIN_1 = pl.DataFrame(
         ],
         "start_time": [ts[0] for ts in TRAIN_1_TIMES],
         "time": TRAIN_1_TIMES,
+        # Both subjects: DOB (1), [{3|2},10,11] (3), [4] (1)
+        "measurements_per_event": [[1, 3, 1], [1, 3, 1]],
     },
     schema=SCHEMAS_SCHEMA,
 )
@@ -293,6 +308,8 @@ WANT_SCHEMAS_TUNING_0 = pl.DataFrame(
         "static_numeric_value": [[None, 0.28697699308395386]],
         "start_time": [ts[0] for ts in TUNING_0_TIMES],
         "time": TUNING_0_TIMES,
+        # DOB (1), [3,10,11] (3), [4] (1)
+        "measurements_per_event": [[1, 3, 1]],
     },
     schema=SCHEMAS_SCHEMA,
 )
@@ -331,6 +348,8 @@ WANT_SCHEMAS_HELD_OUT_0 = pl.DataFrame(
         "static_numeric_value": [[None, -0.7995940446853638]],
         "start_time": [ts[0] for ts in HELD_OUT_0_TIMES],
         "time": HELD_OUT_0_TIMES,
+        # DOB (1), [2,10,11] (3), [10,11] (2), [10,11] (2), [4] (1)
+        "measurements_per_event": [[1, 3, 2, 2, 1]],
     },
     schema=SCHEMAS_SCHEMA,
 )

--- a/tests/test_step_through_sampling.py
+++ b/tests/test_step_through_sampling.py
@@ -1,0 +1,187 @@
+"""Tests for the STEP_THROUGH subsequence sampling strategy."""
+
+import logging
+
+import pytest
+import torch
+
+from meds_torchdata import MEDSPytorchDataset, MEDSTorchDataConfig
+from meds_torchdata.types import SubsequenceSamplingStrategy
+
+
+def test_step_through_requires_positive_stride(tensorized_MEDS_dataset):
+    with pytest.raises(ValueError, match="step_through_stride must be a positive integer"):
+        MEDSTorchDataConfig(
+            tensorized_cohort_dir=tensorized_MEDS_dataset,
+            max_seq_len=3,
+            seq_sampling_strategy="step_through",
+        )
+    with pytest.raises(ValueError, match="step_through_stride must be a positive integer"):
+        MEDSTorchDataConfig(
+            tensorized_cohort_dir=tensorized_MEDS_dataset,
+            max_seq_len=3,
+            seq_sampling_strategy="step_through",
+            step_through_stride=0,
+        )
+
+
+def test_step_through_stride_requires_step_through_strategy(tensorized_MEDS_dataset):
+    with pytest.raises(ValueError, match="may only be set when seq_sampling_strategy is STEP_THROUGH"):
+        MEDSTorchDataConfig(
+            tensorized_cohort_dir=tensorized_MEDS_dataset,
+            max_seq_len=3,
+            seq_sampling_strategy="random",
+            step_through_stride=2,
+        )
+
+
+def test_step_through_subsample_st_offset_raises_not_implemented():
+    with pytest.raises(NotImplementedError, match="STEP_THROUGH is resolved at the dataset-expansion level"):
+        SubsequenceSamplingStrategy.STEP_THROUGH.subsample_st_offset(10, 3)
+
+
+def _step_through_cfg(tensorized_MEDS_dataset, **kwargs):
+    return MEDSTorchDataConfig(
+        tensorized_cohort_dir=tensorized_MEDS_dataset,
+        max_seq_len=3,
+        seq_sampling_strategy="step_through",
+        step_through_stride=2,
+        batch_mode="SEM",
+        **kwargs,
+    )
+
+
+def test_step_through_expands_index_and_emits_warning(tensorized_MEDS_dataset, caplog):
+    cfg = _step_through_cfg(tensorized_MEDS_dataset)
+
+    with caplog.at_level(logging.WARNING, logger="meds_torchdata.pytorch_dataset"):
+        dataset = MEDSPytorchDataset(cfg, split="train")
+
+    assert any("STEP_THROUGH sampling expands each subject" in rec.message for rec in caplog.records), (
+        "Expected oversampling warning to be logged on dataset __init__"
+    )
+
+    # Expansion must preserve the full set of subjects and produce at least as many elements
+    # as there are subjects; subjects with long sequences should contribute more than one.
+    n_subjects = len({s for s, _ in dataset.index})
+    assert len(dataset) >= n_subjects
+    assert dataset.step_through_windows is not None
+    assert dataset.step_through_window_counts is not None
+    assert len(dataset.step_through_windows) == len(dataset)
+    assert len(dataset.step_through_window_counts) == len(dataset)
+
+    # At least one subject must have been expanded into more than one window for the test
+    # to be meaningful.
+    assert max(dataset.step_through_window_counts) > 1
+
+    # Consecutive entries belonging to the same subject must have strictly non-decreasing
+    # window starts (deterministic ordered walk).
+    last_subject = None
+    last_st = -1
+    for (subject_id, _), (st, _) in zip(dataset.index, dataset.step_through_windows, strict=True):
+        if subject_id != last_subject:
+            last_subject = subject_id
+            last_st = st
+            continue
+        assert st >= last_st, f"Window starts must be monotonically non-decreasing for subject {subject_id}"
+        last_st = st
+
+
+def test_step_through_walks_all_events_at_least_once(tensorized_MEDS_dataset):
+    # stride = max_seq_len -> non-overlapping walk; every event should appear exactly once
+    # except the tail, which may appear twice because the last window is anchored to `seq_len`.
+    cfg = MEDSTorchDataConfig(
+        tensorized_cohort_dir=tensorized_MEDS_dataset,
+        max_seq_len=3,
+        seq_sampling_strategy="step_through",
+        step_through_stride=3,
+        batch_mode="SEM",
+    )
+    dataset = MEDSPytorchDataset(cfg, split="train")
+
+    # Group windows by subject and verify every event up to end_idx is covered.
+    per_subject: dict[int, list[tuple[int, int]]] = {}
+    for (subject_id, _end_idx), window in zip(dataset.index, dataset.step_through_windows, strict=True):
+        per_subject.setdefault(subject_id, []).append((window[0], window[1]))
+
+    for subject_id, windows in per_subject.items():
+        covered = set()
+        for st, end in windows:
+            covered.update(range(max(0, st), end))
+        # Determine the sequence length this subject should cover: the common end_idx across
+        # rows (we reuse `dataset._step_through_seq_len_for` via the dataset API).
+        end_idx = next(e for s, e in dataset.index if s == subject_id)
+        expected = dataset._step_through_seq_len_for(subject_id, end_idx)
+        # Every in-range event must appear in at least one window.
+        for pos in range(expected):
+            assert pos in covered, f"Event {pos} for subject {subject_id} not covered"
+
+
+def test_step_through_window_counts_match_loss_reweighting_contract(tensorized_MEDS_dataset):
+    cfg = _step_through_cfg(tensorized_MEDS_dataset, include_subject_window_counts_in_batch=True)
+    dataset = MEDSPytorchDataset(cfg, split="train")
+
+    # Collate a batch containing every element so we cover multiple subjects.
+    samples = [dataset[i] for i in range(len(dataset))]
+    batch = dataset.collate(samples)
+
+    assert batch.n_subject_windows is not None
+    assert batch.n_subject_windows.dtype == torch.long
+    assert batch.n_subject_windows.shape == (len(dataset),)
+
+    # The per-element count equals the number of elements in the dataset that share the same
+    # subject (that is the definition of the reweighting denominator).
+    from collections import Counter
+
+    subj_counts = Counter(subject_id for subject_id, _ in dataset.index)
+    for i, (subject_id, _) in enumerate(dataset.index):
+        assert int(batch.n_subject_windows[i]) == subj_counts[subject_id]
+
+    # Sum of 1 / n_subject_windows across the dataset equals the number of unique subjects:
+    # this is the property that makes reweighted losses unbiased w.r.t. oversampling.
+    reweight_sum = float((1.0 / batch.n_subject_windows.float()).sum().item())
+    assert reweight_sum == pytest.approx(len(set(subj_counts)), abs=1e-6)
+
+
+def test_include_subject_window_counts_without_step_through(tensorized_MEDS_dataset):
+    # Non step-through datasets can still opt in; each sample reports a count of 1.
+    cfg = MEDSTorchDataConfig(
+        tensorized_cohort_dir=tensorized_MEDS_dataset,
+        max_seq_len=3,
+        seq_sampling_strategy="from_start",
+        include_subject_window_counts_in_batch=True,
+    )
+    dataset = MEDSPytorchDataset(cfg, split="train")
+    batch = dataset.collate([dataset[i] for i in range(len(dataset))])
+
+    assert batch.n_subject_windows is not None
+    assert torch.equal(batch.n_subject_windows, torch.ones(len(dataset), dtype=torch.long))
+
+
+def test_step_through_sm_mode_uses_measurement_units(tensorized_MEDS_dataset):
+    # In SM mode, the window must be computed in post-flatten measurement units, not in
+    # events. We verify that explicitly by checking at least one returned window is as long
+    # as `max_seq_len` measurements.
+    cfg = MEDSTorchDataConfig(
+        tensorized_cohort_dir=tensorized_MEDS_dataset,
+        max_seq_len=3,
+        seq_sampling_strategy="step_through",
+        step_through_stride=2,
+        batch_mode="SM",
+    )
+    dataset = MEDSPytorchDataset(cfg, split="train")
+
+    # Iterate through every sample and check the dynamic data length is <= max_seq_len.
+    for i in range(len(dataset)):
+        sample = dataset[i]
+        dyn = sample["dynamic"]
+        # In SM mode process_dynamic_data flattens before slicing; the returned length must
+        # never exceed the configured max_seq_len.
+        assert len(dyn) <= cfg.max_seq_len, (
+            f"Sample {i} returned a window of length {len(dyn)} which exceeds max_seq_len={cfg.max_seq_len}"
+        )
+
+    # And at least one window should realize the full max_seq_len (assuming the test fixture
+    # has a subject with more than `max_seq_len` measurements, which it does).
+    any_full = any(len(dataset[i]["dynamic"]) == cfg.max_seq_len for i in range(len(dataset)))
+    assert any_full

--- a/tests/test_step_through_sampling.py
+++ b/tests/test_step_through_sampling.py
@@ -1,115 +1,34 @@
-"""Tests for the STEP_THROUGH subsequence sampling strategy."""
+"""Tests for the STEP_THROUGH subsequence sampling strategy.
+
+Most of the fine-grained behavior for `STEP_THROUGH` is covered by doctests:
+
+- `MEDSTorchDataConfig` doctest: every config validation error case
+  (stride/overlap types, mutual exclusivity, wrong-strategy rejection, bool rejection).
+- `SubsequenceSamplingStrategy.subsample_st_offset` doctest: the `STEP_THROUGH → TO_END`
+  delegation.
+- `MEDSPytorchDataset._expand_index_for_step_through` doctest: a SEM-mode end-to-end walk
+  with `self.index` / `_windows_per_subject` / per-sample dynamic payload / collated
+  `n_subject_windows` tensor, plus an SM-mode walk showing the Design B property that
+  windows can end mid-event.
+- `MEDSPytorchDataset._effective_max_seq_len_for` doctest: SEM / SM / PREPEND per-subject
+  reductions.
+- `MEDSPytorchDataset._step_through_event_ends_sem` doctest: the SEM event-walk closed
+  form.
+- `MEDSPytorchDataset._step_through_ends_sm` doctest: the SM `searchsorted` walk on the
+  real fixture.
+
+This file keeps only the assertions that the doctest format cannot reasonably express —
+things that need `caplog` inspection, `pytest.parametrize`, or iterating across the whole
+dataset with algorithmic coverage checks.
+"""
 
 import logging
+from collections import Counter
 
 import pytest
 import torch
 
 from meds_torchdata import MEDSPytorchDataset, MEDSTorchDataConfig
-from meds_torchdata.types import SubsequenceSamplingStrategy
-
-
-def test_step_through_requires_positive_stride(tensorized_MEDS_dataset):
-    with pytest.raises(
-        ValueError, match="Exactly one of step_through_stride or step_through_overlap must be set"
-    ):
-        MEDSTorchDataConfig(
-            tensorized_cohort_dir=tensorized_MEDS_dataset,
-            max_seq_len=3,
-            seq_sampling_strategy="step_through",
-        )
-    with pytest.raises(ValueError, match="step_through_stride must be a positive integer"):
-        MEDSTorchDataConfig(
-            tensorized_cohort_dir=tensorized_MEDS_dataset,
-            max_seq_len=3,
-            seq_sampling_strategy="step_through",
-            step_through_stride=0,
-        )
-
-
-def test_step_through_overlap_accepted(tensorized_MEDS_dataset):
-    # `step_through_overlap=0` = contiguous windows; equivalent to stride == effective_window.
-    cfg = MEDSTorchDataConfig(
-        tensorized_cohort_dir=tensorized_MEDS_dataset,
-        max_seq_len=3,
-        seq_sampling_strategy="step_through",
-        step_through_overlap=0,
-        batch_mode="SEM",
-    )
-    dataset = MEDSPytorchDataset(cfg, split="train")
-    assert len(dataset) > 0
-
-
-def test_step_through_overlap_too_large_rejected(tensorized_MEDS_dataset):
-    # overlap >= effective_window would make the resolved stride non-positive, which would
-    # crash `range(..., step=0)` or silently produce an empty walk with step<0. The dataset
-    # must reject this at __init__ time with a clear error about the relationship between
-    # overlap and effective window width.
-    cfg = MEDSTorchDataConfig(
-        tensorized_cohort_dir=tensorized_MEDS_dataset,
-        max_seq_len=3,
-        seq_sampling_strategy="step_through",
-        step_through_overlap=3,  # == max_seq_len, so effective_window - overlap == 0
-        batch_mode="SEM",
-    )
-    with pytest.raises(ValueError, match=r"step_through_overlap .* must be strictly less than"):
-        MEDSPytorchDataset(cfg, split="train")
-
-
-def test_step_through_overlap_rejects_bool_and_negative(tensorized_MEDS_dataset):
-    for bad in (True, False, -1):
-        with pytest.raises(ValueError, match="step_through_overlap must be a non-negative integer"):
-            MEDSTorchDataConfig(
-                tensorized_cohort_dir=tensorized_MEDS_dataset,
-                max_seq_len=3,
-                seq_sampling_strategy="step_through",
-                step_through_overlap=bad,
-            )
-
-
-def test_step_through_stride_and_overlap_mutually_exclusive(tensorized_MEDS_dataset):
-    with pytest.raises(ValueError, match="Exactly one of step_through_stride or step_through_overlap"):
-        MEDSTorchDataConfig(
-            tensorized_cohort_dir=tensorized_MEDS_dataset,
-            max_seq_len=3,
-            seq_sampling_strategy="step_through",
-            step_through_stride=2,
-            step_through_overlap=1,
-        )
-
-
-def test_step_through_stride_rejects_bool(tensorized_MEDS_dataset):
-    # `bool` is a subclass of `int` in Python, so a naive `isinstance(x, int)` check would
-    # silently accept `True` / `False` as stride values. Config validation rejects them.
-    for bad_value in (True, False):
-        with pytest.raises(ValueError, match="step_through_stride must be a positive integer"):
-            MEDSTorchDataConfig(
-                tensorized_cohort_dir=tensorized_MEDS_dataset,
-                max_seq_len=3,
-                seq_sampling_strategy="step_through",
-                step_through_stride=bad_value,
-            )
-
-
-def test_step_through_stride_requires_step_through_strategy(tensorized_MEDS_dataset):
-    with pytest.raises(ValueError, match="may only be set when seq_sampling_strategy is STEP_THROUGH"):
-        MEDSTorchDataConfig(
-            tensorized_cohort_dir=tensorized_MEDS_dataset,
-            max_seq_len=3,
-            seq_sampling_strategy="random",
-            step_through_stride=2,
-        )
-
-
-def test_step_through_subsample_st_offset_delegates_to_to_end():
-    # STEP_THROUGH delegates to TO_END semantics at the sampler level: the dataset has
-    # already modified the index to point to the right prefix endpoint, and the sampler
-    # takes the last `max_seq_len` elements of it.
-    assert SubsequenceSamplingStrategy.STEP_THROUGH.subsample_st_offset(10, 3) == 7
-    assert SubsequenceSamplingStrategy.STEP_THROUGH.subsample_st_offset(10, 3) == (
-        SubsequenceSamplingStrategy.TO_END.subsample_st_offset(10, 3)
-    )
-    assert SubsequenceSamplingStrategy.STEP_THROUGH.subsample_st_offset(5, 10) is None
 
 
 def _step_through_cfg(tensorized_MEDS_dataset, **kwargs):
@@ -123,16 +42,16 @@ def _step_through_cfg(tensorized_MEDS_dataset, **kwargs):
     )
 
 
-def test_step_through_expands_index_and_emits_warning(tensorized_MEDS_dataset, caplog):
+def test_step_through_emits_oversampling_warning(tensorized_MEDS_dataset, caplog):
+    """The dataset logs a `STEP_THROUGH sampling expanded ...` warning on `__init__`.
+
+    This has to be a real test rather than a doctest because it inspects `caplog.records`.
+    """
     cfg = _step_through_cfg(tensorized_MEDS_dataset)
 
     with caplog.at_level(logging.WARNING, logger="meds_torchdata.pytorch_dataset"):
-        dataset = MEDSPytorchDataset(cfg, split="train")
+        MEDSPytorchDataset(cfg, split="train")
 
-    # The warning fires *after* the expansion loop so the numbers it reports are the actual
-    # observed per-subject window counts (in PREPEND mode with per-subject effective windows
-    # a closed-form formula in terms of `config.max_seq_len` would be misleading). Use
-    # `getMessage()` rather than `.message` so %-format arg interpolation happens reliably.
     warning_messages = [rec.getMessage() for rec in caplog.records if rec.levelname == "WARNING"]
     assert any("STEP_THROUGH sampling expanded" in msg for msg in warning_messages), (
         f"Expected oversampling warning on dataset __init__, got: {warning_messages}"
@@ -141,36 +60,14 @@ def test_step_through_expands_index_and_emits_warning(tensorized_MEDS_dataset, c
         "Expected the warning to mention the n_subject_windows reweighting escape hatch"
     )
 
-    # Expansion must preserve the full set of subjects and produce at least as many elements
-    # as there are subjects; subjects with long sequences should contribute more than one.
-    n_subjects = len({s for s, _ in dataset.index})
-    assert len(dataset) >= n_subjects
-    assert dataset._windows_per_subject is not None
-    assert set(dataset._windows_per_subject) == {s for s, _ in dataset.index}
-    # Parallel meas-ends list is `None` in SEM mode (events are atomic there, and the
-    # index's event-level `end` plus TO_END sampling suffices).
-    assert dataset.step_through_meas_ends is None
 
-    # At least one subject must have been expanded into more than one window for the test
-    # to be meaningful.
-    assert max(dataset._windows_per_subject.values()) > 1
+def test_step_through_overlap_zero_covers_every_event(tensorized_MEDS_dataset):
+    """With `step_through_overlap=0` every event in every subject must appear in some window.
 
-    # Consecutive entries belonging to the same subject must have strictly non-decreasing
-    # window ends (deterministic ordered walk).
-    last_subject = None
-    last_end = -1
-    for subject_id, end in dataset.index:
-        if subject_id != last_subject:
-            last_subject = subject_id
-            last_end = end
-            continue
-        assert end >= last_end, f"Window ends must be monotonically non-decreasing for subject {subject_id}"
-        last_end = end
-
-
-def test_step_through_walks_all_events_at_least_once(tensorized_MEDS_dataset):
-    # `step_through_overlap=0` -> contiguous non-overlapping walk in events. Every event
-    # from 0 to the subject's end must appear in at least one window's effective range.
+    The closed form for the event walk is covered by `_step_through_event_ends_sem`'s
+    doctest, but verifying "no event is left behind across the *whole* dataset" requires
+    iterating every subject, which doesn't fit cleanly into a doctest.
+    """
     cfg = MEDSTorchDataConfig(
         tensorized_cohort_dir=tensorized_MEDS_dataset,
         max_seq_len=3,
@@ -180,8 +77,6 @@ def test_step_through_walks_all_events_at_least_once(tensorized_MEDS_dataset):
     )
     dataset = MEDSPytorchDataset(cfg, split="train")
 
-    # Group index entries by subject. In SEM mode, each index entry's `end` is the event
-    # end of the window, and the window contains events [max(0, end - effective_window), end).
     per_subject: dict[int, list[int]] = {}
     for subject_id, end in dataset.index:
         per_subject.setdefault(subject_id, []).append(end)
@@ -191,17 +86,35 @@ def test_step_through_walks_all_events_at_least_once(tensorized_MEDS_dataset):
         covered: set[int] = set()
         for end in ends:
             covered.update(range(max(0, end - effective_window), end))
-        # The subject's full event range must be covered (including the tail-anchored window).
         max_end = max(ends)
         for pos in range(max_end):
             assert pos in covered, f"Event {pos} for subject {subject_id} not covered"
 
 
+def test_step_through_overlap_too_large_rejected(tensorized_MEDS_dataset):
+    """`step_through_overlap >= effective_window` is rejected at dataset __init__."""
+    cfg = MEDSTorchDataConfig(
+        tensorized_cohort_dir=tensorized_MEDS_dataset,
+        max_seq_len=3,
+        seq_sampling_strategy="step_through",
+        step_through_overlap=3,  # == max_seq_len, so effective_window - overlap == 0
+        batch_mode="SEM",
+    )
+    with pytest.raises(ValueError, match=r"step_through_overlap .* must be strictly less than"):
+        MEDSPytorchDataset(cfg, split="train")
+
+
 def test_step_through_window_counts_match_loss_reweighting_contract(tensorized_MEDS_dataset):
+    """`batch.n_subject_windows` satisfies the `sum(1/n) == #subjects` reweighting invariant.
+
+    The sample-level `n_subject_windows` lookup is shown in the
+    `_expand_index_for_step_through` doctest, but the reweighting invariant
+    (`sum(1 / n_subject_windows) == #unique_subjects`) is a property of the whole collated
+    batch — it's the definition of what makes the reweighting unbiased w.r.t. oversampling.
+    """
     cfg = _step_through_cfg(tensorized_MEDS_dataset, include_subject_window_counts_in_batch=True)
     dataset = MEDSPytorchDataset(cfg, split="train")
 
-    # Collate a batch containing every element so we cover multiple subjects.
     samples = [dataset[i] for i in range(len(dataset))]
     batch = dataset.collate(samples)
 
@@ -209,22 +122,16 @@ def test_step_through_window_counts_match_loss_reweighting_contract(tensorized_M
     assert batch.n_subject_windows.dtype == torch.long
     assert batch.n_subject_windows.shape == (len(dataset),)
 
-    # The per-element count equals the number of elements in the dataset that share the same
-    # subject (that is the definition of the reweighting denominator).
-    from collections import Counter
-
     subj_counts = Counter(subject_id for subject_id, _ in dataset.index)
     for i, (subject_id, _) in enumerate(dataset.index):
         assert int(batch.n_subject_windows[i]) == subj_counts[subject_id]
 
-    # Sum of 1 / n_subject_windows across the dataset equals the number of unique subjects:
-    # this is the property that makes reweighted losses unbiased w.r.t. oversampling.
     reweight_sum = float((1.0 / batch.n_subject_windows.float()).sum().item())
     assert reweight_sum == pytest.approx(len(set(subj_counts)), abs=1e-6)
 
 
 def test_include_subject_window_counts_without_step_through(tensorized_MEDS_dataset):
-    # Non step-through datasets can still opt in; each sample reports a count of 1.
+    """Non-step-through datasets that opt into the flag report a uniform count of 1."""
     cfg = MEDSTorchDataConfig(
         tensorized_cohort_dir=tensorized_MEDS_dataset,
         max_seq_len=3,
@@ -242,13 +149,10 @@ def test_include_subject_window_counts_without_step_through(tensorized_MEDS_data
 def test_step_through_prepend_respects_max_seq_len(tensorized_MEDS_dataset, batch_mode):
     """STEP_THROUGH + PREPEND must not produce samples longer than `config.max_seq_len`.
 
-    In PREPEND mode the collated sample is `[static; dynamic]`, so the dynamic window size
-    has to be reduced by the number of static elements being prepended. Prior to the fix the
-    step-through expansion precomputed windows of size `max_seq_len` regardless of mode,
-    which meant the concatenated `[static; dynamic]` sample could exceed `max_seq_len` when
-    `static_inclusion_mode=PREPEND`.
+    Parametrized across `batch_mode` because SEM reserves exactly one event for the static
+    data while SM reserves `len(static_code)` measurements per subject, and both branches
+    need to round-trip end-to-end through `collate`.
     """
-
     cfg = MEDSTorchDataConfig(
         tensorized_cohort_dir=tensorized_MEDS_dataset,
         max_seq_len=8,
@@ -259,7 +163,6 @@ def test_step_through_prepend_respects_max_seq_len(tensorized_MEDS_dataset, batc
     )
     dataset = MEDSPytorchDataset(cfg, split="train")
 
-    # Every single sample — after prepending static data — must have length <= max_seq_len.
     for idx in range(len(dataset)):
         sample = dataset[idx]
         total_len = len(sample["dynamic"])
@@ -268,59 +171,8 @@ def test_step_through_prepend_respects_max_seq_len(tensorized_MEDS_dataset, batc
             f"under batch_mode={batch_mode}, static_inclusion_mode=prepend"
         )
 
-    # And the collated batch must also fit.
     batch = dataset.collate([dataset[i] for i in range(len(dataset))])
     seq_axis = batch.time_delta_days.shape[-1]
     assert seq_axis <= cfg.max_seq_len, (
         f"Collated batch shape {batch.time_delta_days.shape} exceeds max_seq_len={cfg.max_seq_len}"
     )
-
-
-def test_step_through_prepend_effective_window_matches_reduction(tensorized_MEDS_dataset):
-    """The per-subject effective window is exactly `max_seq_len - n_static_seq_els`."""
-
-    cfg = MEDSTorchDataConfig(
-        tensorized_cohort_dir=tensorized_MEDS_dataset,
-        max_seq_len=8,
-        seq_sampling_strategy="step_through",
-        step_through_stride=2,
-        batch_mode="SM",
-        static_inclusion_mode="prepend",
-    )
-    dataset = MEDSPytorchDataset(cfg, split="train")
-
-    for subject_id, _ in set(dataset.index):
-        effective = dataset._effective_max_seq_len_for(subject_id)
-        shard, subj_idx = dataset.subj_locations[subject_id]
-        static_code_list = dataset.schema_dfs_by_shard[shard][subj_idx]["static_code"].item()
-        n_static = len(static_code_list) if static_code_list is not None else 0
-        assert effective == cfg.max_seq_len - n_static
-
-
-def test_step_through_sm_mode_uses_measurement_units(tensorized_MEDS_dataset):
-    # In SM mode, the window must be computed in post-flatten measurement units, not in
-    # events. We verify that explicitly by checking at least one returned window is as long
-    # as `max_seq_len` measurements.
-    cfg = MEDSTorchDataConfig(
-        tensorized_cohort_dir=tensorized_MEDS_dataset,
-        max_seq_len=3,
-        seq_sampling_strategy="step_through",
-        step_through_stride=2,
-        batch_mode="SM",
-    )
-    dataset = MEDSPytorchDataset(cfg, split="train")
-
-    # Iterate through every sample and check the dynamic data length is <= max_seq_len.
-    for i in range(len(dataset)):
-        sample = dataset[i]
-        dyn = sample["dynamic"]
-        # In SM mode process_dynamic_data flattens before slicing; the returned length must
-        # never exceed the configured max_seq_len.
-        assert len(dyn) <= cfg.max_seq_len, (
-            f"Sample {i} returned a window of length {len(dyn)} which exceeds max_seq_len={cfg.max_seq_len}"
-        )
-
-    # And at least one window should realize the full max_seq_len (assuming the test fixture
-    # has a subject with more than `max_seq_len` measurements, which it does).
-    any_full = any(len(dataset[i]["dynamic"]) == cfg.max_seq_len for i in range(len(dataset)))
-    assert any_full

--- a/tests/test_step_through_sampling.py
+++ b/tests/test_step_through_sampling.py
@@ -40,6 +40,22 @@ def test_step_through_overlap_accepted(tensorized_MEDS_dataset):
     assert len(dataset) > 0
 
 
+def test_step_through_overlap_too_large_rejected(tensorized_MEDS_dataset):
+    # overlap >= effective_window would make the resolved stride non-positive, which would
+    # crash `range(..., step=0)` or silently produce an empty walk with step<0. The dataset
+    # must reject this at __init__ time with a clear error about the relationship between
+    # overlap and effective window width.
+    cfg = MEDSTorchDataConfig(
+        tensorized_cohort_dir=tensorized_MEDS_dataset,
+        max_seq_len=3,
+        seq_sampling_strategy="step_through",
+        step_through_overlap=3,  # == max_seq_len, so effective_window - overlap == 0
+        batch_mode="SEM",
+    )
+    with pytest.raises(ValueError, match=r"step_through_overlap .* must be strictly less than"):
+        MEDSPytorchDataset(cfg, split="train")
+
+
 def test_step_through_overlap_rejects_bool_and_negative(tensorized_MEDS_dataset):
     for bad in (True, False, -1):
         with pytest.raises(ValueError, match="step_through_overlap must be a non-negative integer"):
@@ -115,8 +131,9 @@ def test_step_through_expands_index_and_emits_warning(tensorized_MEDS_dataset, c
 
     # The warning fires *after* the expansion loop so the numbers it reports are the actual
     # observed per-subject window counts (in PREPEND mode with per-subject effective windows
-    # a closed-form formula in terms of `config.max_seq_len` would be misleading).
-    warning_messages = [rec.message for rec in caplog.records if rec.levelname == "WARNING"]
+    # a closed-form formula in terms of `config.max_seq_len` would be misleading). Use
+    # `getMessage()` rather than `.message` so %-format arg interpolation happens reliably.
+    warning_messages = [rec.getMessage() for rec in caplog.records if rec.levelname == "WARNING"]
     assert any("STEP_THROUGH sampling expanded" in msg for msg in warning_messages), (
         f"Expected oversampling warning on dataset __init__, got: {warning_messages}"
     )

--- a/tests/test_step_through_sampling.py
+++ b/tests/test_step_through_sampling.py
@@ -25,6 +25,7 @@ dataset with algorithmic coverage checks.
 import logging
 from collections import Counter
 
+import polars as pl
 import pytest
 import torch
 
@@ -89,6 +90,64 @@ def test_step_through_overlap_zero_covers_every_event(tensorized_MEDS_dataset):
         max_end = max(ends)
         for pos in range(max_end):
             assert pos in covered, f"Event {pos} for subject {subject_id} not covered"
+
+
+def test_step_through_sm_errors_on_old_cohort_missing_column(tensorized_MEDS_dataset, tmp_path):
+    """Older tensorized cohorts without `measurements_per_event` get a clear migration error.
+
+    Build a mock "old cohort" by copying the current tensorized cohort and stripping the
+    `measurements_per_event` column from every schema parquet, then point an SM-mode
+    step-through config at it. The dataset must raise a `ValueError` mentioning
+    `MTD_preprocess`, not a low-level parquet/column-not-found traceback. This guards the
+    eager-read migration path in `MEDSPytorchDataset.__init__`.
+    """
+    import shutil
+
+    old_cohort = tmp_path / "old_cohort"
+    shutil.copytree(tensorized_MEDS_dataset, old_cohort)
+
+    # Rewrite every schema parquet without the `measurements_per_event` column.
+    stripped_any = False
+    for schema_fp in (old_cohort / "tokenization" / "schemas").rglob("*.parquet"):
+        df = pl.read_parquet(schema_fp)
+        if "measurements_per_event" in df.columns:
+            df.drop("measurements_per_event").write_parquet(schema_fp)
+            stripped_any = True
+    assert stripped_any, "Test setup expected the current cohort to have the new column"
+
+    cfg = MEDSTorchDataConfig(
+        tensorized_cohort_dir=old_cohort,
+        max_seq_len=5,
+        seq_sampling_strategy="step_through",
+        step_through_stride=3,
+        batch_mode="SM",
+    )
+    with pytest.raises(ValueError) as excinfo:
+        MEDSPytorchDataset(cfg, split="train")
+    msg = str(excinfo.value)
+    assert "STEP_THROUGH sampling in SM mode requires" in msg
+    assert "measurements_per_event" in msg
+    assert "MTD_preprocess" in msg
+
+    # SEM mode and non-step-through configs do *not* need the new column, so they keep
+    # working on the stripped cohort — this is the backward-compat property the eager
+    # column check is there to preserve.
+    sem_cfg = MEDSTorchDataConfig(
+        tensorized_cohort_dir=old_cohort,
+        max_seq_len=3,
+        seq_sampling_strategy="step_through",
+        step_through_stride=2,
+        batch_mode="SEM",
+    )
+    MEDSPytorchDataset(sem_cfg, split="train")  # no error
+
+    random_sm_cfg = MEDSTorchDataConfig(
+        tensorized_cohort_dir=old_cohort,
+        max_seq_len=5,
+        seq_sampling_strategy="random",
+        batch_mode="SM",
+    )
+    MEDSPytorchDataset(random_sm_cfg, split="train")  # no error
 
 
 def test_step_through_overlap_too_large_rejected(tensorized_MEDS_dataset):

--- a/tests/test_step_through_sampling.py
+++ b/tests/test_step_through_sampling.py
@@ -158,6 +158,65 @@ def test_include_subject_window_counts_without_step_through(tensorized_MEDS_data
     assert torch.equal(batch.n_subject_windows, torch.ones(len(dataset), dtype=torch.long))
 
 
+@pytest.mark.parametrize("batch_mode", ["SEM", "SM"])
+def test_step_through_prepend_respects_max_seq_len(tensorized_MEDS_dataset, batch_mode):
+    """STEP_THROUGH + PREPEND must not produce samples longer than `config.max_seq_len`.
+
+    In PREPEND mode the collated sample is `[static; dynamic]`, so the dynamic window size
+    has to be reduced by the number of static elements being prepended. Prior to the fix the
+    step-through expansion precomputed windows of size `max_seq_len` regardless of mode,
+    which meant the concatenated `[static; dynamic]` sample could exceed `max_seq_len` when
+    `static_inclusion_mode=PREPEND`.
+    """
+
+    cfg = MEDSTorchDataConfig(
+        tensorized_cohort_dir=tensorized_MEDS_dataset,
+        max_seq_len=8,
+        seq_sampling_strategy="step_through",
+        step_through_stride=2,
+        batch_mode=batch_mode,
+        static_inclusion_mode="prepend",
+    )
+    dataset = MEDSPytorchDataset(cfg, split="train")
+
+    # Every single sample — after prepending static data — must have length <= max_seq_len.
+    for idx in range(len(dataset)):
+        sample = dataset[idx]
+        total_len = len(sample["dynamic"])
+        assert total_len <= cfg.max_seq_len, (
+            f"Sample {idx} total length {total_len} exceeds max_seq_len={cfg.max_seq_len} "
+            f"under batch_mode={batch_mode}, static_inclusion_mode=prepend"
+        )
+
+    # And the collated batch must also fit.
+    batch = dataset.collate([dataset[i] for i in range(len(dataset))])
+    seq_axis = batch.time_delta_days.shape[-1]
+    assert seq_axis <= cfg.max_seq_len, (
+        f"Collated batch shape {batch.time_delta_days.shape} exceeds max_seq_len={cfg.max_seq_len}"
+    )
+
+
+def test_step_through_prepend_effective_window_matches_reduction(tensorized_MEDS_dataset):
+    """The per-subject effective window is exactly `max_seq_len - n_static_seq_els`."""
+
+    cfg = MEDSTorchDataConfig(
+        tensorized_cohort_dir=tensorized_MEDS_dataset,
+        max_seq_len=8,
+        seq_sampling_strategy="step_through",
+        step_through_stride=2,
+        batch_mode="SM",
+        static_inclusion_mode="prepend",
+    )
+    dataset = MEDSPytorchDataset(cfg, split="train")
+
+    for subject_id, _ in set(dataset.index):
+        effective = dataset._effective_max_seq_len_for(subject_id)
+        shard, subj_idx = dataset.subj_locations[subject_id]
+        static_code_list = dataset.schema_dfs_by_shard[shard][subj_idx]["static_code"].item()
+        n_static = len(static_code_list) if static_code_list is not None else 0
+        assert effective == cfg.max_seq_len - n_static
+
+
 def test_step_through_sm_mode_uses_measurement_units(tensorized_MEDS_dataset):
     # In SM mode, the window must be computed in post-flatten measurement units, not in
     # events. We verify that explicitly by checking at least one returned window is as long

--- a/tests/test_step_through_sampling.py
+++ b/tests/test_step_through_sampling.py
@@ -10,7 +10,9 @@ from meds_torchdata.types import SubsequenceSamplingStrategy
 
 
 def test_step_through_requires_positive_stride(tensorized_MEDS_dataset):
-    with pytest.raises(ValueError, match="step_through_stride must be a positive integer"):
+    with pytest.raises(
+        ValueError, match="Exactly one of step_through_stride or step_through_overlap must be set"
+    ):
         MEDSTorchDataConfig(
             tensorized_cohort_dir=tensorized_MEDS_dataset,
             max_seq_len=3,
@@ -22,6 +24,41 @@ def test_step_through_requires_positive_stride(tensorized_MEDS_dataset):
             max_seq_len=3,
             seq_sampling_strategy="step_through",
             step_through_stride=0,
+        )
+
+
+def test_step_through_overlap_accepted(tensorized_MEDS_dataset):
+    # `step_through_overlap=0` = contiguous windows; equivalent to stride == effective_window.
+    cfg = MEDSTorchDataConfig(
+        tensorized_cohort_dir=tensorized_MEDS_dataset,
+        max_seq_len=3,
+        seq_sampling_strategy="step_through",
+        step_through_overlap=0,
+        batch_mode="SEM",
+    )
+    dataset = MEDSPytorchDataset(cfg, split="train")
+    assert len(dataset) > 0
+
+
+def test_step_through_overlap_rejects_bool_and_negative(tensorized_MEDS_dataset):
+    for bad in (True, False, -1):
+        with pytest.raises(ValueError, match="step_through_overlap must be a non-negative integer"):
+            MEDSTorchDataConfig(
+                tensorized_cohort_dir=tensorized_MEDS_dataset,
+                max_seq_len=3,
+                seq_sampling_strategy="step_through",
+                step_through_overlap=bad,
+            )
+
+
+def test_step_through_stride_and_overlap_mutually_exclusive(tensorized_MEDS_dataset):
+    with pytest.raises(ValueError, match="Exactly one of step_through_stride or step_through_overlap"):
+        MEDSTorchDataConfig(
+            tensorized_cohort_dir=tensorized_MEDS_dataset,
+            max_seq_len=3,
+            seq_sampling_strategy="step_through",
+            step_through_stride=2,
+            step_through_overlap=1,
         )
 
 
@@ -48,9 +85,15 @@ def test_step_through_stride_requires_step_through_strategy(tensorized_MEDS_data
         )
 
 
-def test_step_through_subsample_st_offset_raises_not_implemented():
-    with pytest.raises(NotImplementedError, match="STEP_THROUGH is resolved at the dataset-expansion level"):
-        SubsequenceSamplingStrategy.STEP_THROUGH.subsample_st_offset(10, 3)
+def test_step_through_subsample_st_offset_delegates_to_to_end():
+    # STEP_THROUGH delegates to TO_END semantics at the sampler level: the dataset has
+    # already modified the index to point to the right prefix endpoint, and the sampler
+    # takes the last `max_seq_len` elements of it.
+    assert SubsequenceSamplingStrategy.STEP_THROUGH.subsample_st_offset(10, 3) == 7
+    assert SubsequenceSamplingStrategy.STEP_THROUGH.subsample_st_offset(10, 3) == (
+        SubsequenceSamplingStrategy.TO_END.subsample_st_offset(10, 3)
+    )
+    assert SubsequenceSamplingStrategy.STEP_THROUGH.subsample_st_offset(5, 10) is None
 
 
 def _step_through_cfg(tensorized_MEDS_dataset, **kwargs):
@@ -85,55 +128,55 @@ def test_step_through_expands_index_and_emits_warning(tensorized_MEDS_dataset, c
     # as there are subjects; subjects with long sequences should contribute more than one.
     n_subjects = len({s for s, _ in dataset.index})
     assert len(dataset) >= n_subjects
-    assert dataset.step_through_windows is not None
-    assert len(dataset.step_through_windows) == len(dataset)
     assert dataset._windows_per_subject is not None
     assert set(dataset._windows_per_subject) == {s for s, _ in dataset.index}
+    # Parallel meas-ends list is `None` in SEM mode (events are atomic there, and the
+    # index's event-level `end` plus TO_END sampling suffices).
+    assert dataset.step_through_meas_ends is None
 
     # At least one subject must have been expanded into more than one window for the test
     # to be meaningful.
     assert max(dataset._windows_per_subject.values()) > 1
 
     # Consecutive entries belonging to the same subject must have strictly non-decreasing
-    # window starts (deterministic ordered walk).
+    # window ends (deterministic ordered walk).
     last_subject = None
-    last_st = -1
-    for (subject_id, _), (st, _) in zip(dataset.index, dataset.step_through_windows, strict=True):
+    last_end = -1
+    for subject_id, end in dataset.index:
         if subject_id != last_subject:
             last_subject = subject_id
-            last_st = st
+            last_end = end
             continue
-        assert st >= last_st, f"Window starts must be monotonically non-decreasing for subject {subject_id}"
-        last_st = st
+        assert end >= last_end, f"Window ends must be monotonically non-decreasing for subject {subject_id}"
+        last_end = end
 
 
 def test_step_through_walks_all_events_at_least_once(tensorized_MEDS_dataset):
-    # stride = max_seq_len -> non-overlapping walk; every event should appear exactly once
-    # except the tail, which may appear twice because the last window is anchored to `seq_len`.
+    # `step_through_overlap=0` -> contiguous non-overlapping walk in events. Every event
+    # from 0 to the subject's end must appear in at least one window's effective range.
     cfg = MEDSTorchDataConfig(
         tensorized_cohort_dir=tensorized_MEDS_dataset,
         max_seq_len=3,
         seq_sampling_strategy="step_through",
-        step_through_stride=3,
+        step_through_overlap=0,
         batch_mode="SEM",
     )
     dataset = MEDSPytorchDataset(cfg, split="train")
 
-    # Group windows by subject and verify every event up to end_idx is covered.
-    per_subject: dict[int, list[tuple[int, int]]] = {}
-    for (subject_id, _end_idx), window in zip(dataset.index, dataset.step_through_windows, strict=True):
-        per_subject.setdefault(subject_id, []).append((window[0], window[1]))
+    # Group index entries by subject. In SEM mode, each index entry's `end` is the event
+    # end of the window, and the window contains events [max(0, end - effective_window), end).
+    per_subject: dict[int, list[int]] = {}
+    for subject_id, end in dataset.index:
+        per_subject.setdefault(subject_id, []).append(end)
 
-    for subject_id, windows in per_subject.items():
-        covered = set()
-        for st, end in windows:
-            covered.update(range(max(0, st), end))
-        # Determine the sequence length this subject should cover: the common end_idx across
-        # rows (we reuse `dataset._step_through_seq_len_for` via the dataset API).
-        end_idx = next(e for s, e in dataset.index if s == subject_id)
-        expected = dataset._step_through_seq_len_for(subject_id, end_idx)
-        # Every in-range event must appear in at least one window.
-        for pos in range(expected):
+    for subject_id, ends in per_subject.items():
+        effective_window = dataset._effective_max_seq_len_for(subject_id)
+        covered: set[int] = set()
+        for end in ends:
+            covered.update(range(max(0, end - effective_window), end))
+        # The subject's full event range must be covered (including the tail-anchored window).
+        max_end = max(ends)
+        for pos in range(max_end):
             assert pos in covered, f"Event {pos} for subject {subject_id} not covered"
 
 

--- a/tests/test_step_through_sampling.py
+++ b/tests/test_step_through_sampling.py
@@ -25,6 +25,19 @@ def test_step_through_requires_positive_stride(tensorized_MEDS_dataset):
         )
 
 
+def test_step_through_stride_rejects_bool(tensorized_MEDS_dataset):
+    # `bool` is a subclass of `int` in Python, so a naive `isinstance(x, int)` check would
+    # silently accept `True` / `False` as stride values. Config validation rejects them.
+    for bad_value in (True, False):
+        with pytest.raises(ValueError, match="step_through_stride must be a positive integer"):
+            MEDSTorchDataConfig(
+                tensorized_cohort_dir=tensorized_MEDS_dataset,
+                max_seq_len=3,
+                seq_sampling_strategy="step_through",
+                step_through_stride=bad_value,
+            )
+
+
 def test_step_through_stride_requires_step_through_strategy(tensorized_MEDS_dataset):
     with pytest.raises(ValueError, match="may only be set when seq_sampling_strategy is STEP_THROUGH"):
         MEDSTorchDataConfig(

--- a/tests/test_step_through_sampling.py
+++ b/tests/test_step_through_sampling.py
@@ -86,13 +86,13 @@ def test_step_through_expands_index_and_emits_warning(tensorized_MEDS_dataset, c
     n_subjects = len({s for s, _ in dataset.index})
     assert len(dataset) >= n_subjects
     assert dataset.step_through_windows is not None
-    assert dataset.step_through_window_counts is not None
     assert len(dataset.step_through_windows) == len(dataset)
-    assert len(dataset.step_through_window_counts) == len(dataset)
+    assert dataset._windows_per_subject is not None
+    assert set(dataset._windows_per_subject) == {s for s, _ in dataset.index}
 
     # At least one subject must have been expanded into more than one window for the test
     # to be meaningful.
-    assert max(dataset.step_through_window_counts) > 1
+    assert max(dataset._windows_per_subject.values()) > 1
 
     # Consecutive entries belonging to the same subject must have strictly non-decreasing
     # window starts (deterministic ordered walk).

--- a/tests/test_step_through_sampling.py
+++ b/tests/test_step_through_sampling.py
@@ -57,8 +57,15 @@ def test_step_through_expands_index_and_emits_warning(tensorized_MEDS_dataset, c
     with caplog.at_level(logging.WARNING, logger="meds_torchdata.pytorch_dataset"):
         dataset = MEDSPytorchDataset(cfg, split="train")
 
-    assert any("STEP_THROUGH sampling expands each subject" in rec.message for rec in caplog.records), (
-        "Expected oversampling warning to be logged on dataset __init__"
+    # The warning fires *after* the expansion loop so the numbers it reports are the actual
+    # observed per-subject window counts (in PREPEND mode with per-subject effective windows
+    # a closed-form formula in terms of `config.max_seq_len` would be misleading).
+    warning_messages = [rec.message for rec in caplog.records if rec.levelname == "WARNING"]
+    assert any("STEP_THROUGH sampling expanded" in msg for msg in warning_messages), (
+        f"Expected oversampling warning on dataset __init__, got: {warning_messages}"
+    )
+    assert any("n_subject_windows" in msg for msg in warning_messages), (
+        "Expected the warning to mention the n_subject_windows reweighting escape hatch"
     )
 
     # Expansion must preserve the full set of subjects and produce at least as many elements


### PR DESCRIPTION
## Summary

Adds a new `SubsequenceSamplingStrategy.STEP_THROUGH` that deterministically walks a sliding window of size `max_seq_len` across every subject's full permitted sequence and produces one dataset element per window. The window spacing is controlled by exactly one of `step_through_stride` (absolute number of elements to advance) or `step_through_overlap` (elements to share between consecutive windows — useful because in SM+PREPEND the effective window varies per subject). Both are in the same unit as `max_seq_len`: events in SEM mode, **measurements** in SM mode, so SM-mode windows can legitimately end mid-event.

### Architecture: index expansion + `TO_END` delegation

Instead of maintaining a parallel slice array, step-through simply **modifies `self.index`**: each expanded entry is `(subject_id, end_event_idx)` where `end_event_idx` is the window-specific end event (in SEM mode, the event at the window's end; in SM mode, the smallest event whose prefix contains the measurement-level window end). `SubsequenceSamplingStrategy.STEP_THROUGH.subsample_st_offset(...)` then **delegates to `TO_END`** (`return seq_len - max_seq_len`), so step-through is literally "modify the index, run `TO_END` per entry". This makes `_seeded_getitem` step-through-unaware and eliminates the bespoke branching and parallel slice arrays entirely.

Measurement-level SM windows (which can split events) are handled via a single parallel list `self.step_through_meas_ends: list[int] | None` that stores the measurement-level end for each sample. `_seeded_getitem` passes this through `MEDSTorchDataConfig.process_dynamic_data` via a new `explicit_end: int | None` kwarg. In SEM mode and non-step-through modes this list stays `None`.

### Preprocessing change

`extract_statics_and_schema` now emits an additional `measurements_per_event: list[u32]` column on the subject schema parquet, parallel to the existing `time` list. It gives the measurement count at each unique timestamp so SM-mode step-through can map measurement-level window ends back to event indices via `np.searchsorted` on the cumulative sum. Parquet is columnar, so datasets that never use SM step-through pay zero load cost.

### Config surface

- `step_through_stride: int | None` — advance N elements between windows. Validated positive integer, bool rejected explicitly.
- `step_through_overlap: int | None` — share N elements of overlap between consecutive windows (stride = `effective_window - overlap` per subject). `overlap=0` is contiguous non-overlapping. Validated non-negative integer, bool rejected.
- Exactly one of the two must be set when `seq_sampling_strategy == STEP_THROUGH`; both must be `None` otherwise.
- `include_subject_window_counts_in_batch: bool` — populates `MEDSTorchBatch.n_subject_windows` (shape `[batch_size]`) so downstream code can reweight losses by `1 / n_subject_windows` to undo the oversampling bias that step-through introduces.

### Validation

- Stride/overlap parameter types (positive int / non-negative int, with explicit bool rejection).
- `stride > effective_window` per subject — rejected with a coverage-gap error.
- `stride <= 0` per subject (only reachable via `overlap >= effective_window`) — rejected with an overlap-aware error.
- Task mode is incompatible with step-through and is rejected by config.
- Effective window must be positive per subject (PREPEND can reduce it).

## Test plan

`tests/test_step_through_sampling.py` covers config validation (stride / overlap / mutual exclusivity / bool rejection / overlap-too-large), `STEP_THROUGH → TO_END` delegation, expansion + oversampling warning with observed stats, coverage via `overlap=0`, loss-reweighting contract (`sum(1/n_subject_windows) == #unique_subjects`), `include_subject_window_counts_in_batch=True` without step-through, SEM+PREPEND and SM+PREPEND length invariants, and SM mode window size. Doctests on `_expand_index_for_step_through` walk through SEM + SM examples using the real fixture, including the Design B property that SM-mode windows can legitimately end mid-event.

Pre-existing `tests/preprocessing/test_preprocess_parallel.py` failure reproduces on `dev` and is unrelated. All other tests and doctests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)