### PR TITLE
Fix codecov uploads: add --cov-report=xml

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,13 +26,15 @@ jobs:
 
       - name: Run tests
         run: >
-          uv run pytest -v --cov=src -m "not parallelized and not lightning"
+          uv run pytest -v --cov=src --cov-report=xml
+          -m "not parallelized and not lightning"
           --ignore="benchmark" --ignore="src/meds_torchdata/extensions"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5.5.4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
 
       - name: Install lightning
         run: |
@@ -40,21 +42,23 @@ jobs:
 
       - name: Run doctests with lightning
         run: |
-          uv run pytest -v --cov=src src/meds_torchdata/extensions/lightning_datamodule.py
+          uv run pytest -v --cov=src --cov-report=xml src/meds_torchdata/extensions/lightning_datamodule.py
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5.5.4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
 
       - name: Run test/* tests with lightning
         run: |
-          uv run pytest -v --cov=src tests/ -m "lightning and not parallelized"
+          uv run pytest -v --cov=src --cov-report=xml tests/ -m "lightning and not parallelized"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5.5.4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
 
       - name: Install joblib
         run: |
@@ -62,9 +66,10 @@ jobs:
 
       - name: Run tests with joblib
         run: |
-          uv run pytest -v --cov=src tests/ -m "parallelized and not lightning"
+          uv run pytest -v --cov=src --cov-report=xml tests/ -m "parallelized and not lightning"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5.5.4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml


### PR DESCRIPTION
## Summary

Every `pytest` invocation in `.github/workflows/tests.yaml` passed `--cov=src`, but none passed `--cov-report=xml`. Without that flag, `pytest-cov` only writes a terminal summary and no `coverage.xml` file ever lands on disk, so `codecov/codecov-action@v5` has nothing to upload — which is why the codecov integration has been broken.

Fix: add `--cov-report=xml` to all four pytest commands in `tests.yaml` and point the matching `codecov/codecov-action` steps at `files: ./coverage.xml` explicitly.

## Test plan

- [ ] CI green on the PR (tests, code quality, benchmark).
- [ ] After merge, codecov starts seeing coverage reports from subsequent `main` builds again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)