### PR TITLE
Make SubsequenceSamplingStrategy.subsample_st_offset always return int

### DIFF
--- a/src/meds_torchdata/config.py
+++ b/src/meds_torchdata/config.py
@@ -851,8 +851,6 @@ class MEDSTorchDataConfig:
         effective_seq_len = min(seq_len, explicit_end) if explicit_end is not None else seq_len
 
         st = self.seq_sampling_strategy.subsample_st_offset(effective_seq_len, max_seq_len, rng=rng)
-        if st is None:
-            st = 0
         end = st + max_seq_len
 
         # Clamp the resulting slice: `BALANCED_RANDOM` can return a negative `st` so the

--- a/src/meds_torchdata/types.py
+++ b/src/meds_torchdata/types.py
@@ -94,7 +94,7 @@ class SubsequenceSamplingStrategy(StrEnum):
         seq_len: int,
         max_seq_len: int,
         rng: SEED_OR_RNG = None,
-    ) -> int | None:
+    ) -> int:
         """Subsample starting offset based on maximum sequence length and sampling strategy.
 
         Args:
@@ -105,8 +105,11 @@ class SubsequenceSamplingStrategy(StrEnum):
                 integer, a new generator is created with that seed.
 
         Returns:
-            The (integral) start offset within the sequence based on the sampling strategy, or `None` if no
-            subsampling is required.
+            The (integral) start offset within the sequence based on the sampling strategy. Always an
+            `int`: when `seq_len <= max_seq_len` (no sub-sampling needed) every strategy returns `0`,
+            so callers can slice `data[st : st + max_seq_len]` unconditionally — the `min(seq_len, ...)`
+            clamp in `MEDSTorchDataConfig.process_dynamic_data` handles the short-sequence case. See
+            issue #71 for the history behind dropping the previous `None`-on-fit sentinel.
 
         Examples:
             >>> SubsequenceSamplingStrategy.subsample_st_offset("from_start", 10, 5)
@@ -115,8 +118,8 @@ class SubsequenceSamplingStrategy(StrEnum):
             5
             >>> SubsequenceSamplingStrategy.subsample_st_offset("random", 10, 5, rng=1)
             2
-            >>> SubsequenceSamplingStrategy.RANDOM.subsample_st_offset(10, 10) is None
-            True
+            >>> SubsequenceSamplingStrategy.RANDOM.subsample_st_offset(10, 10)
+            0
 
             `STEP_THROUGH` delegates to `TO_END`: each index entry already points at the
             "load me up to this event" endpoint, so the sampler just takes the last
@@ -125,8 +128,8 @@ class SubsequenceSamplingStrategy(StrEnum):
 
             >>> SubsequenceSamplingStrategy.STEP_THROUGH.subsample_st_offset(10, 5)
             5
-            >>> SubsequenceSamplingStrategy.STEP_THROUGH.subsample_st_offset(5, 10) is None
-            True
+            >>> SubsequenceSamplingStrategy.STEP_THROUGH.subsample_st_offset(5, 10)
+            0
 
             The random sampler must be able to place the window flush against the end of the
             sequence (i.e. sample `st = seq_len - max_seq_len`, so that the last event at index
@@ -151,10 +154,10 @@ class SubsequenceSamplingStrategy(StrEnum):
             >>> sorted(possible_st)
             [-4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 
-            `BALANCED_RANDOM` returns `None` (no subsampling) when the sequence already fits:
+            `BALANCED_RANDOM` returns `0` (no subsampling) when the sequence already fits:
 
-            >>> SubsequenceSamplingStrategy.BALANCED_RANDOM.subsample_st_offset(5, 10) is None
-            True
+            >>> SubsequenceSamplingStrategy.BALANCED_RANDOM.subsample_st_offset(5, 10)
+            0
 
             >>> SubsequenceSamplingStrategy.subsample_st_offset("foo", 10, 5)
             Traceback (most recent call last):
@@ -163,7 +166,9 @@ class SubsequenceSamplingStrategy(StrEnum):
         """
 
         if seq_len <= max_seq_len:
-            return None
+            # No sub-sampling needed — caller will slice `data[0 : min(seq_len, max_seq_len)]`
+            # and get the whole sequence. Return `0` so the signature stays monomorphic.
+            return 0
 
         match self:
             case SubsequenceSamplingStrategy.RANDOM:


### PR DESCRIPTION
Closes #71.

## Summary

Previously `subsample_st_offset` returned `int | None`, where `None` meant "sequence already fits, no sub-sampling needed". Every caller (`MEDSTorchDataConfig.process_dynamic_data`) immediately converted `None` to `0` via `if st is None: st = 0`, so the sentinel was doing no real work — dropping it simplifies typing with no behavior change.

## Changes

- `types.py`:
  - Return annotation `int | None` → `int`.
  - The `if seq_len <= max_seq_len: return None` short-circuit becomes `return 0` (with an inline comment explaining the contract: the caller will slice `data[0 : min(seq_len, max_seq_len)]` and get the whole sequence).
  - Updated the three `is None` doctests to assert `== 0` (RANDOM, STEP_THROUGH, BALANCED_RANDOM short-subject cases).
  - `Returns:` docstring updated to describe the new unconditional-`int` contract.
- `config.py`:
  - `MEDSTorchDataConfig.process_dynamic_data` drops the `if st is None: st = 0` fallback.

## Test plan

- [x] Full local suite: 70 passed.
- [x] types.py doctests all green (support sweeps, TO_END delegation, balanced-random integer support).
- [x] config.py doctests all green (all the `process_dynamic_data` examples still produce the same output, since the sentinel was never user-visible).
- [x] No test file asserts `is None` on `subsample_st_offset` — all such checks were doctests, updated in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)