### PR TITLE
Pin NRT dtypes in convert_to_NRT for shard stability (#64)

### DIFF
--- a/src/meds_torchdata/preprocessing/tensorization.py
+++ b/src/meds_torchdata/preprocessing/tensorization.py
@@ -3,6 +3,7 @@
 import logging
 from functools import partial
 
+import numpy as np
 import polars as pl
 from MEDS_transforms.mapreduce import map_stage
 from MEDS_transforms.mapreduce.shard_iteration import shard_iterator
@@ -11,6 +12,15 @@ from nested_ragged_tensors.ragged_numpy import JointNestedRaggedTensorDict
 from omegaconf import DictConfig
 
 logger = logging.getLogger(__name__)
+
+# Pin the on-disk NRT dtypes for each tensorized column. Without an explicit schema,
+# JointNestedRaggedTensorDict auto-infers dtypes from observed values, which varies
+# shard-to-shard — a small shard may land on uint8 while a large one lands on uint32.
+# Pinning `code` to int64 also makes the downstream `.long()` cast in collate a no-op,
+# and pinning the float columns to float32 avoids silent widening to float64.
+NRT_CODE_DTYPE = np.int64
+NRT_NUMERIC_DTYPE = np.float32
+NRT_TIME_DELTA_DTYPE = np.float32
 
 
 def convert_to_NRT(df: pl.LazyFrame) -> JointNestedRaggedTensorDict:
@@ -30,32 +40,44 @@ def convert_to_NRT(df: pl.LazyFrame) -> JointNestedRaggedTensorDict:
         ValueError: If there are no time delta columns or if there are multiple time delta columns.
 
     Examples:
-        >>> df = pl.DataFrame({
-        ...     "subject_id": [1, 2],
-        ...     "time_delta_days": [[float("nan"), 12.0], [float("nan")]],
-        ...     "code": [[[101.0, 102.0], [103.0]], [[201.0, 202.0]]],
-        ...     "numeric_value": [[[2.0, 3.0], [4.0]], [[6.0, 7.0]]]
-        ... })
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "subject_id": [1, 2],
+        ...         "time_delta_days": [[float("nan"), 12.0], [float("nan")]],
+        ...         "code": [[[101, 102], [103]], [[201, 202]]],
+        ...         "numeric_value": [[[2.0, 3.0], [4.0]], [[6.0, 7.0]]],
+        ...     },
+        ...     schema={
+        ...         "subject_id": pl.Int64,
+        ...         "time_delta_days": pl.List(pl.Float32),
+        ...         "code": pl.List(pl.List(pl.Int64)),
+        ...         "numeric_value": pl.List(pl.List(pl.Float32)),
+        ...     },
+        ... )
         >>> df
         shape: (2, 4)
-        ┌────────────┬─────────────────┬───────────────────────────┬─────────────────────┐
-        │ subject_id ┆ time_delta_days ┆ code                      ┆ numeric_value       │
-        │ ---        ┆ ---             ┆ ---                       ┆ ---                 │
-        │ i64        ┆ list[f64]       ┆ list[list[f64]]           ┆ list[list[f64]]     │
-        ╞════════════╪═════════════════╪═══════════════════════════╪═════════════════════╡
-        │ 1          ┆ [NaN, 12.0]     ┆ [[101.0, 102.0], [103.0]] ┆ [[2.0, 3.0], [4.0]] │
-        │ 2          ┆ [NaN]           ┆ [[201.0, 202.0]]          ┆ [[6.0, 7.0]]        │
-        └────────────┴─────────────────┴───────────────────────────┴─────────────────────┘
+        ┌────────────┬─────────────────┬─────────────────────┬─────────────────────┐
+        │ subject_id ┆ time_delta_days ┆ code                ┆ numeric_value       │
+        │ ---        ┆ ---             ┆ ---                 ┆ ---                 │
+        │ i64        ┆ list[f32]       ┆ list[list[i64]]     ┆ list[list[f32]]     │
+        ╞════════════╪═════════════════╪═════════════════════╪═════════════════════╡
+        │ 1          ┆ [NaN, 12.0]     ┆ [[101, 102], [103]] ┆ [[2.0, 3.0], [4.0]] │
+        │ 2          ┆ [NaN]           ┆ [[201, 202]]        ┆ [[6.0, 7.0]]        │
+        └────────────┴─────────────────┴─────────────────────┴─────────────────────┘
         >>> nrt = convert_to_NRT(df.lazy())
+        >>> nrt.schema  # doctest: +NORMALIZE_WHITESPACE
+        {'time_delta_days': <class 'numpy.float32'>,
+         'code': <class 'numpy.int64'>,
+         'numeric_value': <class 'numpy.float32'>}
         >>> for k, v in sorted(list(nrt.to_dense().items())):
         ...     print(k)
         ...     print(v)
         code
-        [[[101. 102.]
-          [103.   0.]]
+        [[[101 102]
+          [103   0]]
         <BLANKLINE>
-         [[201. 202.]
-          [  0.   0.]]]
+         [[201 202]
+          [  0   0]]]
         dim1/mask
         [[ True  True]
          [ True False]]
@@ -117,7 +139,12 @@ def convert_to_NRT(df: pl.LazyFrame) -> JointNestedRaggedTensorDict:
         logger.warning("All columns are empty. Returning an empty tensor dict.")
         return JointNestedRaggedTensorDict({})
 
-    return JointNestedRaggedTensorDict(tensors_dict)
+    schema = {
+        time_delta_col: NRT_TIME_DELTA_DTYPE,
+        "code": NRT_CODE_DTYPE,
+        "numeric_value": NRT_NUMERIC_DTYPE,
+    }
+    return JointNestedRaggedTensorDict(tensors_dict, schema=schema)
 
 
 @Stage.register(is_metadata=False)

--- a/src/meds_torchdata/pytorch_dataset.py
+++ b/src/meds_torchdata/pytorch_dataset.py
@@ -332,7 +332,7 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
             >>> sample["dynamic"].to_dense()["code"]
             array([[ 5,  0,  0],
                    [ 1, 10, 11],
-                   [10, 11,  0]], dtype=uint8)
+                   [10, 11,  0]])
 
             Collated batches surface `n_subject_windows` as a `[batch_size]` tensor — use
             `1 / n_subject_windows` as a per-sample loss weight to undo oversampling:
@@ -377,7 +377,7 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
             regardless of where event boundaries fall:
 
             >>> sm_pyd[1]["dynamic"].to_dense()["code"]
-            array([11, 10, 11, 10, 11], dtype=uint8)
+            array([11, 10, 11, 10, 11])
             >>> len(sm_pyd[1]["dynamic"])
             5
 
@@ -385,7 +385,7 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
             5 measurements wide:
 
             >>> sm_pyd[2]["dynamic"].to_dense()["code"]
-            array([10, 11, 10, 11,  4], dtype=uint8)
+            array([10, 11, 10, 11,  4])
             >>> len(sm_pyd[2]["dynamic"])
             5
         """


### PR DESCRIPTION
## Summary

- Pass an explicit \`schema=\` to \`JointNestedRaggedTensorDict\` in \`convert_to_NRT\` so \`code\` is always \`int64\` and \`numeric_value\` / \`time_delta_days\` are always \`float32\`.
- Without this, NRT auto-infers dtypes from observed values — a small shard can serialize \`code\` as \`uint8\` and a large one as \`uint32\`, and downstream consumers are at the mercy of shard-by-shard narrowing.
- Pinning \`code\` to \`int64\` also makes the \`.long()\` cast in \`collate\` a no-op instead of a widening conversion.

Closes #64.

## Test plan

- [x] \`uv run pytest -v --no-cov src/meds_torchdata/preprocessing/tensorization.py\` (new doctest asserts \`nrt.schema == {..., 'code': np.int64, ...}\`).
- [x] \`uv run pytest -q --no-cov -m "not parallelized and not lightning" --ignore=benchmark --ignore=src/meds_torchdata/extensions\` (67 passed after updating three doctests in \`pytorch_dataset.py\` that asserted the previous auto-inferred \`dtype=uint8\`).
- [ ] CI green on the 0.5.x MEDS-Transforms pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)