### PR TITLE
docs: fix Args section of subsample_st_offset (#79)

### DIFF
--- a/src/meds_torchdata/types.py
+++ b/src/meds_torchdata/types.py
@@ -97,10 +97,14 @@ class SubsequenceSamplingStrategy(StrEnum):
     ) -> int | None:
         """Subsample starting offset based on maximum sequence length and sampling strategy.
 
+        The method is an ordinary instance method on the enum; callers typically invoke it via the
+        class-level sugar `SubsequenceSamplingStrategy.subsample_st_offset(strategy, ...)`, which
+        binds `strategy` (one of `RANDOM`, `BALANCED_RANDOM`, `TO_END`, `FROM_START`,
+        `STEP_THROUGH`, or the equivalent string value) to `self` and forwards the rest.
+
         Args:
-            strategy: Strategy for selecting subsequence (RANDOM, TO_END, FROM_START)
-            seq_len: Length of the sequence
-            max_seq_len: Maximum allowed sequence length
+            seq_len: Length of the sequence.
+            max_seq_len: Maximum allowed sequence length.
             rng: Random number generator for random sampling. If None, a new generator is created. If an
                 integer, a new generator is created with that seed.
 


### PR DESCRIPTION
## Summary

- Closes #79 (follow-up to Copilot review on #73).
- Rewrites the `Args:` block of `SubsequenceSamplingStrategy.subsample_st_offset` to (a) describe the calling convention instead of claiming a non-existent `strategy` parameter, and (b) list all five strategies rather than three.

## Why this is docstring-only

The phantom `strategy:` entry corresponded to the class-level calling sugar (`SubsequenceSamplingStrategy.subsample_st_offset("random", ...)`) where the first positional argument binds to `self`. The signature itself has no `strategy` parameter, so the original entry confused readers; and the strategy enumeration was frozen at `(RANDOM, TO_END, FROM_START)` and never updated when `BALANCED_RANDOM` and `STEP_THROUGH` were added (both exercised in the Examples block directly below).

## Test plan

- [x] `uv run pytest --doctest-modules src/meds_torchdata/types.py` — all doctests still pass (8 passed).
- [ ] CI green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)