### PR TITLE
refactor: subprocess shell=False + env dict for ETL (#80)

### DIFF
--- a/src/meds_torchdata/preprocessing/__main__.py
+++ b/src/meds_torchdata/preprocessing/__main__.py
@@ -36,23 +36,18 @@ def main(cfg: DictConfig):
     # old `~parallelize` override used to.
     n_workers = int(os.getenv("N_WORKERS", 1))
 
-    command_parts = [
-        f"INPUT_DIR={MEDS_dataset_dir.resolve()!s}",
-        f"OUTPUT_DIR={output_dir.resolve()!s}",
-        "MEDS_transform-pipeline",
-        str(etl_cfg.resolve()),
-    ]
+    cmd = ["MEDS_transform-pipeline", str(etl_cfg.resolve())]
 
     user_stage_runner_fp = stage_runner_fp
     synthesized_runner_path: Path | None = None
     if user_stage_runner_fp:
-        command_parts.extend(["--stage_runner_fp", str(user_stage_runner_fp)])
+        cmd.extend(["--stage_runner_fp", str(user_stage_runner_fp)])
     elif n_workers > 1:
         synthesized = {"parallelize": {"n_workers": n_workers, "launcher": "joblib"}}
         tmp_dir = Path(tempfile.mkdtemp(prefix="mtd_stage_runner_"))
         synthesized_runner_path = tmp_dir / "stage_runner.yaml"
         synthesized_runner_path.write_text(yaml.safe_dump(synthesized))
-        command_parts.extend(["--stage_runner_fp", str(synthesized_runner_path)])
+        cmd.extend(["--stage_runner_fp", str(synthesized_runner_path)])
     else:
         logger.info(f"Running in serial mode (n_workers={n_workers} <= 1).")
 
@@ -61,13 +56,20 @@ def main(cfg: DictConfig):
         overrides.append(f"do_overwrite={cfg.do_overwrite}")
 
     if overrides:
-        command_parts.append("--overrides")
-        command_parts.extend(overrides)
+        cmd.append("--overrides")
+        cmd.extend(overrides)
 
-    full_cmd = " ".join(command_parts)
-    logger.info(f"Running command: {full_cmd}")
+    # `MEDS_transform-pipeline` reads `INPUT_DIR` / `OUTPUT_DIR` from the environment rather than
+    # from CLI flags, so we pass them via `env=` to avoid the `shell=True` / string-joining path
+    # that would otherwise corrupt dataset paths containing spaces or shell metacharacters.
+    env = {
+        **os.environ,
+        "INPUT_DIR": str(MEDS_dataset_dir.resolve()),
+        "OUTPUT_DIR": str(output_dir.resolve()),
+    }
+    logger.info(f"Running command: INPUT_DIR={env['INPUT_DIR']} OUTPUT_DIR={env['OUTPUT_DIR']} {cmd}")
     try:
-        command_out = subprocess.run(full_cmd, shell=True, capture_output=True)
+        command_out = subprocess.run(cmd, capture_output=True, text=True, env=env)
     finally:
         if synthesized_runner_path is not None:
             try:
@@ -78,8 +80,8 @@ def main(cfg: DictConfig):
 
     if command_out.returncode != 0:
         logger.error(f"Command failed with return code {command_out.returncode}.")
-        logger.error(f"Command stdout:\n{command_out.stdout.decode()}")
-        logger.error(f"Command stderr:\n{command_out.stderr.decode()}")
+        logger.error(f"Command stdout:\n{command_out.stdout}")
+        logger.error(f"Command stderr:\n{command_out.stderr}")
         raise ValueError(f"Command failed with return code {command_out.returncode}.")
     else:
-        logger.debug(f"Command stdout:\n{command_out.stdout.decode()}")
+        logger.debug(f"Command stdout:\n{command_out.stdout}")

--- a/tests/preprocessing/test_preprocess.py
+++ b/tests/preprocessing/test_preprocess.py
@@ -3,6 +3,7 @@
 Only checks tokenized and tensorized outputs.
 """
 
+import shutil
 import subprocess
 import tempfile
 from pathlib import Path
@@ -61,6 +62,38 @@ def test_preprocess(tensorized_MEDS_dataset: Path):
 
         assert fp.exists(), err_str
         check_NRT_output(fp, want_NRT, f"{shard} NRT differs!")
+
+
+def test_preprocess_path_with_spaces(simple_static_MEDS: Path):
+    """MEDS_dataset_dir / output_dir containing spaces must not break the inner ETL subprocess.
+
+    The outer `MTD_preprocess` hydra invocation is run without `shell=True` so the spaces in the
+    override values reach hydra intact; the regression this guards against is the *inner*
+    `MEDS_transform-pipeline` subprocess corrupting space-containing paths when they pass
+    through via `INPUT_DIR` / `OUTPUT_DIR`.
+    """
+
+    with tempfile.TemporaryDirectory() as root_dir:
+        spaced_src = Path(root_dir) / "input with space"
+        shutil.copytree(simple_static_MEDS, spaced_src)
+
+        spaced_out = Path(root_dir) / "output with space"
+
+        command = [
+            str(PREPROCESS_SCRIPT),
+            f"MEDS_dataset_dir={spaced_src.resolve()!s}",
+            f"output_dir={spaced_out.resolve()!s}",
+        ]
+
+        out = subprocess.run(command, shell=False, check=False, capture_output=True, text=True)
+
+        assert out.returncode == 0, (
+            f"Preprocess failed on a path with spaces (rc={out.returncode}).\n"
+            f"stdout:\n{out.stdout}\nstderr:\n{out.stderr}"
+        )
+
+        assert any(spaced_out.rglob("*.parquet")), "No parquet outputs produced."
+        assert any(spaced_out.rglob("*.nrt")), "No NRT outputs produced."
 
 
 def test_preprocess_error_case():


### PR DESCRIPTION
## Summary

- Closes #80 (follow-up to Copilot review on #77).
- Stacked on top of #77 (`feat/meds-transforms-0.6`) — targets that branch directly so the diff is just this change. Once #77 lands in \`dev\`, I'll re-target to \`dev\`.
- Swaps the `MEDS_transform-pipeline` subprocess call from a `KEY=VAL cmd ...` string with `shell=True` to a list-invocation with `shell=False`, moving `INPUT_DIR` / `OUTPUT_DIR` into the `env=` arg.
- Adds `test_preprocess_path_with_spaces` as a regression guard for dataset/output paths containing spaces.

## Why

The old invocation corrupted any dataset path containing a space (common on user Desktops, Dropbox folders, etc.) because the smuggled env-var prefix relied on shell word-splitting. Moving to `env=` + list args removes both the corruption and the (narrower) shell-injection surface for config-driven values. Also switches to `text=True` so the logger branches don't call `.decode()` manually.

## Test plan

- [x] `uv run pytest tests/preprocessing/test_preprocess.py tests/preprocessing/test_preprocess_parallel.py` — 5 passed (serial + parallel + new spaces test).
- [x] Pre-commit hooks clean.
- [ ] CI green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)