### PR TITLE
RC #91 review polish: header fixes + E2E smoke test

### DIFF
--- a/src/meds_torchdata/preprocessing/tensorization/examples/default/out_data.yaml
+++ b/src/meds_torchdata/preprocessing/tensorization/examples/default/out_data.yaml
@@ -1,4 +1,5 @@
-# Expected NRTs for the `multi_shard` scenario — one per input shard.
+# Expected NRTs for the `default` scenario — one per input shard.
+# (Multi-shard baseline — historically under `examples/multi_shard/`, consolidated here.)
 data/train/0.nrt:
   time_delta_days:
     - [.nan, 10.0]

--- a/src/meds_torchdata/preprocessing/tokenization/examples/default/out_data.yaml
+++ b/src/meds_torchdata/preprocessing/tokenization/examples/default/out_data.yaml
@@ -1,6 +1,9 @@
-# Expected tokenization output for the `multi_shard` scenario.
+# Expected tokenization output for the `default` scenario.
 # Each input shard yields a matching `schemas/<shard>.parquet` and
 # `event_seqs/<shard>.parquet` under the stage's output dir.
+# (This baseline exercises multi-shard iteration across three splits — historically
+# this lived under an `examples/multi_shard/` dir and was consolidated into `default/`
+# since that coverage strictly superseded the single-shard case.)
 data/schemas/train/0.parquet:
   subject_id: [1, 2]
   static_code:

--- a/tests/preprocessing/test_preprocess.py
+++ b/tests/preprocessing/test_preprocess.py
@@ -2,13 +2,19 @@
 
 End-to-end pipeline semantics (stage chain + output validation) live in
 `test_stages.py::test_pipeline_*`. This file covers the wrapper's CLI contract only:
-help output, space-containing paths, and the missing-input error path.
+help output, space-containing paths, and the missing-input error path — plus one
+golden-shape smoke test (`test_preprocess_end_to_end`) that validates outputs
+produced through the wrapper itself, since the pipeline tests invoke
+`MEDS_transform-pipeline` directly and bypass `__main__.py`.
 """
 
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
+
+import polars as pl
+from nested_ragged_tensors.ragged_numpy import JointNestedRaggedTensorDict
 
 PREPROCESS_SCRIPT = "MTD_preprocess"
 
@@ -35,9 +41,11 @@ MTD_preprocess MEDS_dataset_dir=/path/to/dataset output_dir=/path/to/output do_o
 
 
 def test_preprocess_help():
-    out = subprocess.run(f"{PREPROCESS_SCRIPT} --help", shell=True, check=True, capture_output=True)
+    out = subprocess.run(
+        [PREPROCESS_SCRIPT, "--help"], shell=False, check=True, capture_output=True, text=True
+    )
     assert out.returncode == 0
-    assert out.stdout.decode().strip() == HELP_STR.strip()
+    assert out.stdout.strip() == HELP_STR.strip()
 
 
 def test_preprocess_path_with_spaces(simple_static_MEDS: Path):
@@ -109,6 +117,64 @@ def test_preprocess_stage_runner_fp_passthrough(simple_static_MEDS: Path):
             "YAML was actually loaded by the inner `MEDS_transform-pipeline` invocation.\n"
             f"stdout:\n{out.stdout}\nstderr:\n{out.stderr}"
         )
+
+
+def test_preprocess_end_to_end(simple_static_MEDS: Path):
+    """Golden-shape smoke test exercising the full wrapper → pipeline → stages path.
+
+    `test_stages.py::test_pipeline_*` validates golden outputs but invokes
+    `MEDS_transform-pipeline` directly, bypassing `MTD_preprocess.__main__`. This test
+    closes that gap: it runs the real CLI entrypoint and checks that the produced
+    `data/schemas/*.parquet`, `data/event_seqs/*.parquet`, and `data/*.nrt` outputs exist,
+    are readable, and carry the expected top-level columns / tensor keys. It doesn't
+    pin exact values (the pipeline tests already do that more rigorously); the point is
+    to catch wrapper-side regressions — config synthesis, subprocess plumbing, config
+    path resolution — that the golden pipeline tests would miss.
+    """
+
+    with tempfile.TemporaryDirectory() as root_dir:
+        cohort_dir = Path(root_dir) / "cohort"
+
+        command = [
+            PREPROCESS_SCRIPT,
+            f"MEDS_dataset_dir={simple_static_MEDS!s}",
+            f"output_dir={cohort_dir!s}",
+        ]
+        out = subprocess.run(command, shell=False, check=False, capture_output=True, text=True)
+        assert out.returncode == 0, (
+            f"MTD_preprocess failed (rc={out.returncode}).\nstdout:\n{out.stdout}\nstderr:\n{out.stderr}"
+        )
+
+        # MTD_preprocess lays out per-stage intermediate outputs under `<stage>/` subdirs
+        # and the final tensorization outputs under `data/`. (pipeline_tester uses the same
+        # convention — see `MEDS_transforms/pytest_plugin.py::pipeline_tester`.)
+        schemas = sorted((cohort_dir / "tokenization" / "schemas").rglob("*.parquet"))
+        event_seqs = sorted((cohort_dir / "tokenization" / "event_seqs").rglob("*.parquet"))
+        nrts = sorted(fp for fp in (cohort_dir / "data").rglob("*.nrt"))
+        assert schemas, f"No schema parquets produced under {cohort_dir}/tokenization/schemas/"
+        assert event_seqs, f"No event_seqs parquets produced under {cohort_dir}/tokenization/event_seqs/"
+        assert nrts, f"No NRT files produced under {cohort_dir}/data/"
+        assert len(schemas) == len(event_seqs) == len(nrts), (
+            f"Shard-count mismatch: {len(schemas)} schemas, {len(event_seqs)} event_seqs, {len(nrts)} NRTs"
+        )
+
+        for fp in schemas:
+            df = pl.read_parquet(fp)
+            assert {"subject_id", "static_code", "static_numeric_value", "time"}.issubset(df.columns), (
+                f"Schema parquet {fp} missing expected columns; got {df.columns}"
+            )
+
+        for fp in event_seqs:
+            df = pl.read_parquet(fp)
+            assert {"subject_id", "code", "time_delta_days", "numeric_value"}.issubset(df.columns), (
+                f"Event-seqs parquet {fp} missing expected columns; got {df.columns}"
+            )
+
+        for fp in nrts:
+            nrt = JointNestedRaggedTensorDict(tensors_fp=fp)
+            assert nrt.keys() == {"code", "numeric_value", "time_delta_days"}, (
+                f"NRT {fp} has keys {nrt.keys()}, expected {{code, numeric_value, time_delta_days}}"
+            )
 
 
 def test_preprocess_error_case():

--- a/tests/preprocessing/test_preprocess.py
+++ b/tests/preprocessing/test_preprocess.py
@@ -125,11 +125,12 @@ def test_preprocess_end_to_end(simple_static_MEDS: Path):
     `test_stages.py::test_pipeline_*` validates golden outputs but invokes
     `MEDS_transform-pipeline` directly, bypassing `MTD_preprocess.__main__`. This test
     closes that gap: it runs the real CLI entrypoint and checks that the produced
-    `data/schemas/*.parquet`, `data/event_seqs/*.parquet`, and `data/*.nrt` outputs exist,
-    are readable, and carry the expected top-level columns / tensor keys. It doesn't
-    pin exact values (the pipeline tests already do that more rigorously); the point is
-    to catch wrapper-side regressions — config synthesis, subprocess plumbing, config
-    path resolution — that the golden pipeline tests would miss.
+    `tokenization/schemas/*.parquet`, `tokenization/event_seqs/*.parquet`, and
+    `data/*.nrt` outputs exist, are readable, and carry the expected top-level columns /
+    tensor keys. It doesn't pin exact values (the pipeline tests already do that more
+    rigorously); the point is to catch wrapper-side regressions — config synthesis,
+    subprocess plumbing, config path resolution — that the golden pipeline tests would
+    miss.
     """
 
     with tempfile.TemporaryDirectory() as root_dir:


### PR DESCRIPTION
Small follow-up into dev to address Copilot + ChatGPT comments on #91.

## Changes

- **Stale `multi_shard` headers** in `tokenization/examples/default/out_data.yaml` and `tensorization/examples/default/out_data.yaml` — scenarios were consolidated into `default/` in an earlier PR, but the header comments still referenced the old `multi_shard` name. (Copilot threads 3106823682 / 3106823692.)
- **`test_preprocess_help`** now uses argv list + `shell=False` + `text=True`, matching the hardened-subprocess pattern the rest of the wrapper tests use. (Copilot thread 3106823671.)
- **New `test_preprocess_end_to_end`** — golden-shape smoke test that runs the real `MTD_preprocess` CLI and asserts the expected output layout and readability of `tokenization/{schemas,event_seqs}/*.parquet` and `data/*.nrt`. Closes the wrapper/pipeline coverage gap flagged in ChatGPT's review on #91, where the existing pipeline tests invoke `MEDS_transform-pipeline` directly and bypass `MTD_preprocess.__main__`.

## Test plan

- [x] `uv run pytest tests/` — 32 passed, 2 skipped (lightning)
- [ ] CI green