### PR TITLE
Lock MEDSTorchDataConfig against post-handoff mutation (#81)

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,14 @@ File path parameters include:
 - `tensorized_cohort_dir`: The directory containing the tensorized data.
 - `task_labels_dir`: The directory containing the task labels files.
 
+> [!NOTE]
+> `MEDSTorchDataConfig` is an immutable (frozen) dataclass. To derive a modified config,
+> use `dataclasses.replace(cfg, field=value)` and construct a fresh `MEDSPytorchDataset`
+> around it; direct assignment like `cfg.field = value` raises `FrozenInstanceError`.
+> Immutability protects against silently inconsistent state when a `DataLoader` with
+> `persistent_workers=True` (the default for `num_workers>0` via `Datamodule`) keeps
+> worker-process dataset copies alive across epochs.
+
 It also provides a convenient property to get the vocab size for the dataset, given by the vocab indices in
 the tensorized metadata. Let's start by building a configuration object for this data and inspect some of its
 file-path related properties and helpers:
@@ -299,6 +307,7 @@ subject IDs and the end of the allowed region of reading for the dataset. We can
 format via the `schema_df`:
 
 ```python
+>>> import dataclasses
 >>> from meds_torchdata import MEDSPytorchDataset
 >>> cfg = MEDSTorchDataConfig(tensorized_cohort_dir=tensorized_MEDS_dataset, max_seq_len=5)
 >>> pyd = MEDSPytorchDataset(cfg, split="train")
@@ -542,8 +551,13 @@ This example shows what the output looks like if we set the static data inclusio
 we set it to `"prepend"` instead? To show this in a stable manner, we'll also use the seeded version of the
 get item function, `_seeded_getitem`:
 
+`MEDSTorchDataConfig` is frozen after construction; `dataclasses.replace` builds a new
+config with the override and we rebuild the dataset around it.
+
 ```python
->>> pyd.config.static_inclusion_mode = "prepend"
+>>> pyd = MEDSPytorchDataset(
+...     dataclasses.replace(pyd.config, static_inclusion_mode="prepend"), split="train"
+... )
 >>> print_element(pyd._seeded_getitem(2, seed=0))
 n_static_seq_els (int):
 2
@@ -556,7 +570,9 @@ numeric_value
 .
 time_delta_days
 [       nan        nan 0.         0.         0.09787037]
->>> pyd.config.static_inclusion_mode = "include"
+>>> pyd = MEDSPytorchDataset(
+...     dataclasses.replace(pyd.config, static_inclusion_mode="include"), split="train"
+... )
 
 ```
 
@@ -786,7 +802,9 @@ a separate entry in the batch. What about with the other two options, `"omit"` a
 If we use `"omit"`, we can see that the static data is omitted from the output:
 
 ```python
->>> pyd_with_task.config.static_inclusion_mode = "omit"
+>>> pyd_with_task = MEDSPytorchDataset(
+...     dataclasses.replace(pyd_with_task.config, static_inclusion_mode="omit"), split="train"
+... )
 >>> print(next(iter(pyd_with_task.get_dataloader(batch_size=2))))
 MEDSTorchBatch:
 │ Mode: Subject-Measurement (SM)
@@ -825,7 +843,9 @@ What if we use a static inclusion mode of `"prepend"`? We can see that the stati
 dynamic data:
 
 ```python
->>> pyd_with_task.config.static_inclusion_mode = "prepend"
+>>> pyd_with_task = MEDSPytorchDataset(
+...     dataclasses.replace(pyd_with_task.config, static_inclusion_mode="prepend"), split="train"
+... )
 >>> print(next(iter(pyd_with_task.get_dataloader(batch_size=2))))
 MEDSTorchBatch:
 │ Mode: Subject-Measurement (SM)
@@ -860,7 +880,10 @@ MEDSTorchBatch:
 │ │ Labels:
 │ │ │ boolean_value (torch.bool):
 │ │ │ │ [False,  True]
->>> pyd_with_task.config.static_inclusion_mode = "include" # reset to default
+>>> pyd_with_task = MEDSPytorchDataset(
+...     dataclasses.replace(pyd_with_task.config, static_inclusion_mode="include"),
+...     split="train",
+... )  # reset to default
 
 ```
 
@@ -869,7 +892,9 @@ default output to be at a _measurement_ level, rather than an _event_ level, by 
 `batch_mode` to `SM`. Let's see what happens if we change that:
 
 ```python
->>> pyd.config.batch_mode = "SEM"
+>>> pyd = MEDSPytorchDataset(
+...     dataclasses.replace(pyd.config, batch_mode="SEM"), split="train"
+... )
 >>> print_element(pyd[2])
 static_code (list):
 [8, 9]
@@ -953,7 +978,9 @@ MEDSTorchBatch:
 │ │ │ static_numeric_value_mask (torch.bool):
 │ │ │ │ [[False,  True],
 │ │ │ │  [False,  True]]
->>> pyd_with_task.config.batch_mode = "SEM"
+>>> pyd_with_task = MEDSPytorchDataset(
+...     dataclasses.replace(pyd_with_task.config, batch_mode="SEM"), split="train"
+... )
 >>> print(next(iter(pyd_with_task.get_dataloader(batch_size=2))))
 MEDSTorchBatch:
 │ Mode: Subject-Event-Measurement (SEM)
@@ -1022,7 +1049,9 @@ MEDSTorchBatch:
 │ │ Labels:
 │ │ │ boolean_value (torch.bool):
 │ │ │ │ [False,  True]
->>> pyd_with_task.config.static_inclusion_mode = "omit"
+>>> pyd_with_task = MEDSPytorchDataset(
+...     dataclasses.replace(pyd_with_task.config, static_inclusion_mode="omit"), split="train"
+... )
 >>> print(next(iter(pyd_with_task.get_dataloader(batch_size=2))))
 MEDSTorchBatch:
 │ Mode: Subject-Event-Measurement (SEM)
@@ -1079,7 +1108,9 @@ MEDSTorchBatch:
 │ │ Labels:
 │ │ │ boolean_value (torch.bool):
 │ │ │ │ [False,  True]
->>> pyd_with_task.config.static_inclusion_mode = "prepend"
+>>> pyd_with_task = MEDSPytorchDataset(
+...     dataclasses.replace(pyd_with_task.config, static_inclusion_mode="prepend"), split="train"
+... )
 >>> print(next(iter(pyd_with_task.get_dataloader(batch_size=2))))
 MEDSTorchBatch:
 │ Mode: Subject-Event-Measurement (SEM)

--- a/README.md
+++ b/README.md
@@ -229,12 +229,12 @@ File path parameters include:
 - `task_labels_dir`: The directory containing the task labels files.
 
 > [!NOTE]
-> `MEDSTorchDataConfig` is an immutable (frozen) dataclass. To derive a modified config,
-> use `dataclasses.replace(cfg, field=value)` and construct a fresh `MEDSPytorchDataset`
-> around it; direct assignment like `cfg.field = value` raises `FrozenInstanceError`.
-> Immutability protects against silently inconsistent state when a `DataLoader` with
-> `persistent_workers=True` (the default for `num_workers>0` via `Datamodule`) keeps
-> worker-process dataset copies alive across epochs.
+> A `MEDSTorchDataConfig` is freely mutable until you hand it to a `MEDSPytorchDataset`;
+> after that, it's locked against further mutation. This catches the silent-failure case
+> where a post-handoff `cfg.field = value` would fail to propagate into a live dataset (or
+> into worker processes under `persistent_workers=True`, the default from `Datamodule`
+> when `num_workers > 0`). To derive a modified config, use `dataclasses.replace(cfg, field=value)` and construct a fresh `MEDSPytorchDataset` around it — the error message
+> points at the same idiom.
 
 It also provides a convenient property to get the vocab size for the dataset, given by the vocab indices in
 the tensorized metadata. Let's start by building a configuration object for this data and inspect some of its

--- a/README.md
+++ b/README.md
@@ -230,11 +230,13 @@ File path parameters include:
 
 > [!NOTE]
 > A `MEDSTorchDataConfig` is freely mutable until you hand it to a `MEDSPytorchDataset`;
-> after that, it's locked against further mutation. This catches the silent-failure case
-> where a post-handoff `cfg.field = value` would fail to propagate into a live dataset (or
-> into worker processes under `persistent_workers=True`, the default from `Datamodule`
-> when `num_workers > 0`). To derive a modified config, use `dataclasses.replace(cfg, field=value)` and construct a fresh `MEDSPytorchDataset` around it — the error message
-> points at the same idiom.
+> at that point the dataset calls `cfg.lock()` on it, and further `cfg.field = value`
+> mutations raise `RuntimeError` with a pointer to the fix. This catches the silent-failure
+> case where a post-handoff mutation would fail to propagate into the dataset (or into
+> worker processes under `persistent_workers=True`, the default for `num_workers > 0` via
+> `Datamodule`). To derive a modified config, use `dataclasses.replace(cfg, field=value)`
+> and construct a fresh `MEDSPytorchDataset` around it; `cfg.unlock()` is available as a
+> loudly-warned escape hatch for users who accept that the mutation will not propagate.
 
 It also provides a convenient property to get the vocab size for the dataset, given by the vocab indices in
 the tensorized metadata. Let's start by building a configuration object for this data and inspect some of its
@@ -551,8 +553,9 @@ This example shows what the output looks like if we set the static data inclusio
 we set it to `"prepend"` instead? To show this in a stable manner, we'll also use the seeded version of the
 get item function, `_seeded_getitem`:
 
-`MEDSTorchDataConfig` is frozen after construction; `dataclasses.replace` builds a new
-config with the override and we rebuild the dataset around it.
+`pyd.config` is locked (`MEDSPytorchDataset` calls `cfg.lock()` on handoff);
+`dataclasses.replace` builds a new config with the override and we rebuild the
+dataset around it.
 
 ```python
 >>> pyd = MEDSPytorchDataset(

--- a/src/meds_torchdata/config.py
+++ b/src/meds_torchdata/config.py
@@ -14,14 +14,14 @@ import numpy as np
 import polars as pl
 from hydra.core.config_store import ConfigStore
 from nested_ragged_tensors.ragged_numpy import JointNestedRaggedTensorDict
-from omegaconf import OmegaConf, open_dict
+from omegaconf import open_dict
 
 from .types import BatchMode, PaddingSide, StaticInclusionMode, SubsequenceSamplingStrategy
 
 logger = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True)
+@dataclass
 class MEDSTorchDataConfig:
     """A data class for storing configuration options for building a PyTorch dataset from a MEDS dataset.
 
@@ -449,24 +449,11 @@ class MEDSTorchDataConfig:
                 node = node[key]
 
         node = node[f"{cls.__name__}.yaml"].node
-        # `frozen=True` propagates through OmegaConf's dataclass adapter as `readonly=True`
-        # on the node, which blocks both the `_target_` injection here *and* downstream
-        # Hydra `compose(overrides=...)` calls. The Python-level immutability contract
-        # (preventing `config.X = Y` after construction) is orthogonal to whether the
-        # Hydra-layer override mechanism works, so un-set readonly on the stored schema
-        # while still letting `MEDSTorchDataConfig(...)` remain frozen at the Python
-        # boundary. `open_dict` lifts struct mode so `_target_` (undeclared on the dataclass)
-        # can be added.
-        OmegaConf.set_readonly(node, False)
         with open_dict(node):
             node["_target_"] = f"{cls.__module__}.{cls.__name__}"
 
     def __post_init__(self):
-        # `frozen=True` blocks plain `self.x = ...` assignments; normalizing inputs to their
-        # canonical types at construction time requires `object.__setattr__` on the frozen
-        # instance. This is the documented frozen-dataclass escape hatch for __post_init__
-        # coercion; callers can't use it because it's explicitly not a public API.
-        object.__setattr__(self, "tensorized_cohort_dir", Path(self.tensorized_cohort_dir))
+        self.tensorized_cohort_dir = Path(self.tensorized_cohort_dir)
         if not self.tensorized_cohort_dir.is_dir():
             raise FileNotFoundError(
                 "tensorized_cohort_dir must be a valid directory. "
@@ -475,9 +462,7 @@ class MEDSTorchDataConfig:
 
         match self.static_inclusion_mode:
             case str() if self.static_inclusion_mode in {x.value for x in StaticInclusionMode}:
-                object.__setattr__(
-                    self, "static_inclusion_mode", StaticInclusionMode(self.static_inclusion_mode)
-                )
+                self.static_inclusion_mode = StaticInclusionMode(self.static_inclusion_mode)
             case StaticInclusionMode():  # pragma: no cover
                 pass
             case _:
@@ -485,18 +470,14 @@ class MEDSTorchDataConfig:
 
         match self.seq_sampling_strategy:
             case str() if self.seq_sampling_strategy in {x.value for x in SubsequenceSamplingStrategy}:
-                object.__setattr__(
-                    self,
-                    "seq_sampling_strategy",
-                    SubsequenceSamplingStrategy(self.seq_sampling_strategy),
-                )
+                self.seq_sampling_strategy = SubsequenceSamplingStrategy(self.seq_sampling_strategy)
             case SubsequenceSamplingStrategy():  # pragma: no cover
                 pass
             case _:
                 raise ValueError(f"Invalid subsequence sampling strategy: {self.seq_sampling_strategy}")
 
         if self.task_labels_dir is not None:
-            object.__setattr__(self, "task_labels_dir", Path(self.task_labels_dir))
+            self.task_labels_dir = Path(self.task_labels_dir)
             if not self.task_labels_dir.is_dir():
                 raise FileNotFoundError(
                     "If specified, task_labels_dir must be a valid directory. "
@@ -551,6 +532,41 @@ class MEDSTorchDataConfig:
                     "step_through_overlap may only be set when seq_sampling_strategy is STEP_THROUGH; "
                     f"got strategy {self.seq_sampling_strategy} with overlap {self.step_through_overlap!r}."
                 )
+
+    def __setattr__(self, key: str, value) -> None:
+        """Reject mutations after the config has been handed off to a dataset.
+
+        `MEDSPytorchDataset` flips `_handed_off_to_dataset` on the config it receives (via
+        `object.__setattr__`, which bypasses this hook) and works from that captured state
+        for its entire lifetime — schema columns loaded, index construction, JNRT cache
+        keys, worker pickles. A post-handoff mutation on the main-process cfg would
+        silently fail to propagate to the dataset (or to workers under `persistent_workers=True`
+        from #107), desynchronizing state from config. Block the mutation with a pointer
+        to the idiomatic workaround (`dataclasses.replace`).
+
+        Examples:
+            >>> import dataclasses
+            >>> from meds_torchdata import MEDSPytorchDataset, MEDSTorchDataConfig
+            >>> cfg = MEDSTorchDataConfig(tensorized_cohort_dir=tensorized_MEDS_dataset, max_seq_len=5)
+            >>> cfg.max_seq_len = 10  # pre-handoff mutation: fine
+            >>> cfg.max_seq_len
+            10
+            >>> pyd = MEDSPytorchDataset(cfg, split="train")
+            >>> cfg.max_seq_len = 20  # doctest: +ELLIPSIS
+            Traceback (most recent call last):
+                ...
+            RuntimeError: Cannot mutate `max_seq_len` on a MEDSTorchDataConfig...
+        """
+        if getattr(self, "_handed_off_to_dataset", False):
+            raise RuntimeError(
+                f"Cannot mutate `{key}` on a MEDSTorchDataConfig after it has been passed "
+                "to a MEDSPytorchDataset — the dataset works from the config's state at "
+                "construction time, so the mutation would silently not take effect "
+                "(and would not reach worker processes under `persistent_workers=True`). "
+                f"Use `dataclasses.replace(cfg, {key}=...)` to derive a modified config "
+                "and construct a fresh MEDSPytorchDataset."
+            )
+        object.__setattr__(self, key, value)
 
     @property
     def code_metadata_fp(self) -> Path:

--- a/src/meds_torchdata/config.py
+++ b/src/meds_torchdata/config.py
@@ -14,14 +14,14 @@ import numpy as np
 import polars as pl
 from hydra.core.config_store import ConfigStore
 from nested_ragged_tensors.ragged_numpy import JointNestedRaggedTensorDict
-from omegaconf import open_dict
+from omegaconf import OmegaConf, open_dict
 
 from .types import BatchMode, PaddingSide, StaticInclusionMode, SubsequenceSamplingStrategy
 
 logger = logging.getLogger(__name__)
 
 
-@dataclass
+@dataclass(frozen=True)
 class MEDSTorchDataConfig:
     """A data class for storing configuration options for building a PyTorch dataset from a MEDS dataset.
 
@@ -449,11 +449,24 @@ class MEDSTorchDataConfig:
                 node = node[key]
 
         node = node[f"{cls.__name__}.yaml"].node
+        # `frozen=True` propagates through OmegaConf's dataclass adapter as `readonly=True`
+        # on the node, which blocks both the `_target_` injection here *and* downstream
+        # Hydra `compose(overrides=...)` calls. The Python-level immutability contract
+        # (preventing `config.X = Y` after construction) is orthogonal to whether the
+        # Hydra-layer override mechanism works, so un-set readonly on the stored schema
+        # while still letting `MEDSTorchDataConfig(...)` remain frozen at the Python
+        # boundary. `open_dict` lifts struct mode so `_target_` (undeclared on the dataclass)
+        # can be added.
+        OmegaConf.set_readonly(node, False)
         with open_dict(node):
             node["_target_"] = f"{cls.__module__}.{cls.__name__}"
 
     def __post_init__(self):
-        self.tensorized_cohort_dir = Path(self.tensorized_cohort_dir)
+        # `frozen=True` blocks plain `self.x = ...` assignments; normalizing inputs to their
+        # canonical types at construction time requires `object.__setattr__` on the frozen
+        # instance. This is the documented frozen-dataclass escape hatch for __post_init__
+        # coercion; callers can't use it because it's explicitly not a public API.
+        object.__setattr__(self, "tensorized_cohort_dir", Path(self.tensorized_cohort_dir))
         if not self.tensorized_cohort_dir.is_dir():
             raise FileNotFoundError(
                 "tensorized_cohort_dir must be a valid directory. "
@@ -462,7 +475,9 @@ class MEDSTorchDataConfig:
 
         match self.static_inclusion_mode:
             case str() if self.static_inclusion_mode in {x.value for x in StaticInclusionMode}:
-                self.static_inclusion_mode = StaticInclusionMode(self.static_inclusion_mode)
+                object.__setattr__(
+                    self, "static_inclusion_mode", StaticInclusionMode(self.static_inclusion_mode)
+                )
             case StaticInclusionMode():  # pragma: no cover
                 pass
             case _:
@@ -470,14 +485,18 @@ class MEDSTorchDataConfig:
 
         match self.seq_sampling_strategy:
             case str() if self.seq_sampling_strategy in {x.value for x in SubsequenceSamplingStrategy}:
-                self.seq_sampling_strategy = SubsequenceSamplingStrategy(self.seq_sampling_strategy)
+                object.__setattr__(
+                    self,
+                    "seq_sampling_strategy",
+                    SubsequenceSamplingStrategy(self.seq_sampling_strategy),
+                )
             case SubsequenceSamplingStrategy():  # pragma: no cover
                 pass
             case _:
                 raise ValueError(f"Invalid subsequence sampling strategy: {self.seq_sampling_strategy}")
 
         if self.task_labels_dir is not None:
-            self.task_labels_dir = Path(self.task_labels_dir)
+            object.__setattr__(self, "task_labels_dir", Path(self.task_labels_dir))
             if not self.task_labels_dir.is_dir():
                 raise FileNotFoundError(
                     "If specified, task_labels_dir must be a valid directory. "

--- a/src/meds_torchdata/config.py
+++ b/src/meds_torchdata/config.py
@@ -533,38 +533,97 @@ class MEDSTorchDataConfig:
                     f"got strategy {self.seq_sampling_strategy} with overlap {self.step_through_overlap!r}."
                 )
 
-    def __setattr__(self, key: str, value) -> None:
-        """Reject mutations after the config has been handed off to a dataset.
+    def lock(self) -> None:
+        """Lock this config against further mutation.
 
-        `MEDSPytorchDataset` flips `_handed_off_to_dataset` on the config it receives (via
-        `object.__setattr__`, which bypasses this hook) and works from that captured state
-        for its entire lifetime — schema columns loaded, index construction, JNRT cache
-        keys, worker pickles. A post-handoff mutation on the main-process cfg would
-        silently fail to propagate to the dataset (or to workers under `persistent_workers=True`
-        from #107), desynchronizing state from config. Block the mutation with a pointer
-        to the idiomatic workaround (`dataclasses.replace`).
+        Called automatically by `MEDSPytorchDataset.__init__` so the dataset can rely on
+        its config being stable across its lifetime — schema columns loaded, index
+        construction, JNRT cache keys, worker pickles. Idempotent; locking an already-locked
+        config is a no-op.
+
+        To mutate a locked config, either call `unlock()` first (with the caveat that the
+        change will not propagate into an already-attached dataset or its workers) or use
+        `dataclasses.replace(cfg, field=value)` to derive a new config.
 
         Examples:
-            >>> import dataclasses
             >>> from meds_torchdata import MEDSPytorchDataset, MEDSTorchDataConfig
             >>> cfg = MEDSTorchDataConfig(tensorized_cohort_dir=tensorized_MEDS_dataset, max_seq_len=5)
-            >>> cfg.max_seq_len = 10  # pre-handoff mutation: fine
+            >>> cfg.max_seq_len = 10  # mutable pre-lock
             >>> cfg.max_seq_len
             10
+            >>> cfg.lock()
+            >>> cfg.max_seq_len = 20  # doctest: +ELLIPSIS
+            Traceback (most recent call last):
+                ...
+            RuntimeError: Cannot mutate `max_seq_len` on a locked MEDSTorchDataConfig...
+
+            `MEDSPytorchDataset.__init__` calls `lock()` on its input, so direct construction
+            produces the same locked state:
+
+            >>> cfg = MEDSTorchDataConfig(tensorized_cohort_dir=tensorized_MEDS_dataset, max_seq_len=5)
             >>> pyd = MEDSPytorchDataset(cfg, split="train")
             >>> cfg.max_seq_len = 20  # doctest: +ELLIPSIS
             Traceback (most recent call last):
                 ...
-            RuntimeError: Cannot mutate `max_seq_len` on a MEDSTorchDataConfig...
+            RuntimeError: Cannot mutate `max_seq_len` on a locked MEDSTorchDataConfig...
         """
-        if getattr(self, "_handed_off_to_dataset", False):
+        object.__setattr__(self, "_locked", True)
+
+    def unlock(self) -> None:
+        """Unlock a previously-locked config.
+
+        Emits a `UserWarning` when called on a currently-locked config — the typical
+        source of the lock is a `MEDSPytorchDataset` that has already captured the config's
+        state, so post-unlock mutations will not propagate into that dataset's
+        main-process view *or* its worker-process copies (which live on separate cfg
+        snapshots under `persistent_workers=True`, the default when `num_workers > 0`).
+        Users who explicitly want the escape hatch get it; they get a loud pointer at the
+        idiomatic alternative (`dataclasses.replace` + fresh `MEDSPytorchDataset`) too.
+
+        Examples:
+            >>> import warnings
+            >>> cfg = MEDSTorchDataConfig(tensorized_cohort_dir=tensorized_MEDS_dataset, max_seq_len=5)
+            >>> cfg.lock()
+            >>> with warnings.catch_warnings(record=True) as caught:
+            ...     warnings.simplefilter("always")
+            ...     cfg.unlock()
+            ...     print(len(caught), caught[0].category.__name__)
+            1 UserWarning
+            >>> cfg.max_seq_len = 99  # mutable again
+            >>> cfg.max_seq_len
+            99
+
+            Calling `unlock()` on an already-unlocked config is a silent no-op:
+
+            >>> with warnings.catch_warnings(record=True) as caught:
+            ...     warnings.simplefilter("always")
+            ...     cfg.unlock()
+            ...     print(len(caught))
+            0
+        """
+        if getattr(self, "_locked", False):
+            import warnings
+
+            warnings.warn(
+                "Unlocking a locked MEDSTorchDataConfig. If this config is attached to a "
+                "MEDSPytorchDataset, post-unlock mutations will not propagate into the "
+                "dataset's main-process state or its worker-process copies. Prefer "
+                "`dataclasses.replace(cfg, field=value)` and constructing a fresh "
+                "MEDSPytorchDataset.",
+                stacklevel=2,
+            )
+        object.__setattr__(self, "_locked", False)
+
+    def __setattr__(self, key: str, value) -> None:
+        if getattr(self, "_locked", False):
             raise RuntimeError(
-                f"Cannot mutate `{key}` on a MEDSTorchDataConfig after it has been passed "
-                "to a MEDSPytorchDataset — the dataset works from the config's state at "
-                "construction time, so the mutation would silently not take effect "
-                "(and would not reach worker processes under `persistent_workers=True`). "
-                f"Use `dataclasses.replace(cfg, {key}=...)` to derive a modified config "
-                "and construct a fresh MEDSPytorchDataset."
+                f"Cannot mutate `{key}` on a locked MEDSTorchDataConfig. The lock is set "
+                "automatically when the config is handed to `MEDSPytorchDataset`, because "
+                "the dataset captures its state at init time and mutations here would not "
+                "propagate (and would not reach worker processes under "
+                "`persistent_workers=True`). Either call `cfg.unlock()` first (accepting "
+                "that caveat) or use `dataclasses.replace(cfg, "
+                f"{key}=...)` to derive a new config and construct a fresh dataset."
             )
         object.__setattr__(self, key, value)
 

--- a/src/meds_torchdata/config.py
+++ b/src/meds_torchdata/config.py
@@ -552,7 +552,7 @@ class MEDSTorchDataConfig:
             >>> cfg.max_seq_len
             10
             >>> cfg.lock()
-            >>> cfg.max_seq_len = 20  # doctest: +ELLIPSIS
+            >>> cfg.max_seq_len = 20
             Traceback (most recent call last):
                 ...
             RuntimeError: Cannot mutate `max_seq_len` on a locked MEDSTorchDataConfig...
@@ -562,7 +562,7 @@ class MEDSTorchDataConfig:
 
             >>> cfg = MEDSTorchDataConfig(tensorized_cohort_dir=tensorized_MEDS_dataset, max_seq_len=5)
             >>> pyd = MEDSPytorchDataset(cfg, split="train")
-            >>> cfg.max_seq_len = 20  # doctest: +ELLIPSIS
+            >>> cfg.max_seq_len = 20
             Traceback (most recent call last):
                 ...
             RuntimeError: Cannot mutate `max_seq_len` on a locked MEDSTorchDataConfig...

--- a/src/meds_torchdata/config.py
+++ b/src/meds_torchdata/config.py
@@ -580,6 +580,18 @@ class MEDSTorchDataConfig:
         Users who explicitly want the escape hatch get it; they get a loud pointer at the
         idiomatic alternative (`dataclasses.replace` + fresh `MEDSPytorchDataset`) too.
 
+        **Which fields can be mutated safely after unlock?** None of them in a
+        `num_workers > 0` DataLoader — workers pickle their own snapshot at spawn and
+        never see main-process mutations. In a **single-process** setting (`num_workers=0`,
+        direct `dataset[i]` access), the fields read fresh per hot-path call — and thus
+        safe to flip — are `padding_side`, `include_numeric_value`, `include_time_delta`,
+        `include_subject_window_counts_in_batch`, and `max_seq_len` when
+        `seq_sampling_strategy != STEP_THROUGH`. Every other field (sampling strategy,
+        batch mode, static mode, task labels dir, step-through params, window-last-observed,
+        tensorized cohort dir) is baked into dataset init state and flipping it
+        post-handoff leaves the dataset in an inconsistent state. For those, use
+        `dataclasses.replace(cfg, field=value)` + construct a fresh dataset instead.
+
         Examples:
             >>> import warnings
             >>> cfg = MEDSTorchDataConfig(tensorized_cohort_dir=tensorized_MEDS_dataset, max_seq_len=5)

--- a/src/meds_torchdata/pytorch_dataset.py
+++ b/src/meds_torchdata/pytorch_dataset.py
@@ -233,6 +233,12 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
     def __init__(self, cfg: MEDSTorchDataConfig, split: str):
         super().__init__()
 
+        # Lock the cfg against post-handoff mutation — see `MEDSTorchDataConfig.__setattr__`
+        # for the full rationale. `object.__setattr__` bypasses our own lock hook, which is
+        # the only way to set the sentinel itself. Idempotent: reusing the same cfg across
+        # multiple datasets just re-asserts the same flag.
+        object.__setattr__(cfg, "_handed_off_to_dataset", True)
+
         self.config: MEDSTorchDataConfig = cfg
         self.split: str = split
 

--- a/src/meds_torchdata/pytorch_dataset.py
+++ b/src/meds_torchdata/pytorch_dataset.py
@@ -1172,13 +1172,18 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
 
             In `StaticInclusionMode.OMIT` the static slot is returned as `None` rather than an
             empty `StaticData` — the static columns are never loaded from disk in that mode, so
-            there is genuinely nothing to surface:
+            there is genuinely nothing to surface. `MEDSTorchDataConfig` is frozen, so swap in
+            a modified config by constructing a fresh dataset (`dataclasses.replace` is the
+            idiomatic Python way to derive a new config with overrides):
 
-            >>> sample_pytorch_dataset.config.static_inclusion_mode = StaticInclusionMode.OMIT
-            >>> _, static_data = sample_pytorch_dataset.load_subject_data(68729, 0, 3)
+            >>> import dataclasses
+            >>> omit_cfg = dataclasses.replace(
+            ...     sample_pytorch_dataset.config, static_inclusion_mode=StaticInclusionMode.OMIT
+            ... )
+            >>> omit_pyd = MEDSPytorchDataset(omit_cfg, split="train")
+            >>> _, static_data = omit_pyd.load_subject_data(68729, 0, 3)
             >>> static_data is None
             True
-            >>> sample_pytorch_dataset.config.static_inclusion_mode = StaticInclusionMode.INCLUDE
 
             The JNRT handle is cached per `(shard, frozenset(load_keys))` on the dataset
             instance, so repeated calls that hit the same shard reuse one handle rather
@@ -1350,9 +1355,16 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
             you can set it to "left" for generative use cases. To show this, we'll also set the sampling
             strategy to `SubsequenceSamplingStrategy.TO_END` so that things are consistent.
 
+            >>> import dataclasses
             >>> from meds_torchdata.types import SubsequenceSamplingStrategy
-            >>> sample_pytorch_dataset.config.padding_side = "left"
-            >>> sample_pytorch_dataset.config.seq_sampling_strategy = SubsequenceSamplingStrategy.TO_END
+            >>> sample_pytorch_dataset = MEDSPytorchDataset(
+            ...     dataclasses.replace(
+            ...         sample_pytorch_dataset.config,
+            ...         padding_side="left",
+            ...         seq_sampling_strategy=SubsequenceSamplingStrategy.TO_END,
+            ...     ),
+            ...     split="train",
+            ... )
             >>> raw_batch = [sample_pytorch_dataset[i] for i in range(len(sample_pytorch_dataset))]
             >>> print(sample_pytorch_dataset.collate(raw_batch))
             MEDSTorchBatch:
@@ -1406,7 +1418,10 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
             │ │ │ │  [False,  True],
             │ │ │ │  [False,  True],
             │ │ │ │  [False,  True]]
-            >>> sample_pytorch_dataset.config.padding_side = "right"
+            >>> sample_pytorch_dataset = MEDSPytorchDataset(
+            ...     dataclasses.replace(sample_pytorch_dataset.config, padding_side="right"),
+            ...     split="train",
+            ... )
             >>> raw_batch = [sample_pytorch_dataset[i] for i in range(len(sample_pytorch_dataset))]
             >>> print(sample_pytorch_dataset.collate(raw_batch))
             MEDSTorchBatch:
@@ -1463,8 +1478,14 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
 
             Static data can also be omitted if set in the config.
 
-            >>> sample_pytorch_dataset.config.static_inclusion_mode = StaticInclusionMode.OMIT
-            >>> sample_pytorch_dataset.config.seq_sampling_strategy = SubsequenceSamplingStrategy.RANDOM
+            >>> sample_pytorch_dataset = MEDSPytorchDataset(
+            ...     dataclasses.replace(
+            ...         sample_pytorch_dataset.config,
+            ...         static_inclusion_mode=StaticInclusionMode.OMIT,
+            ...         seq_sampling_strategy=SubsequenceSamplingStrategy.RANDOM,
+            ...     ),
+            ...     split="train",
+            ... )
             >>> raw_batch = [sample_pytorch_dataset[2], sample_pytorch_dataset[3]]
             >>> print(sample_pytorch_dataset.collate(raw_batch))
             MEDSTorchBatch:
@@ -1495,8 +1516,14 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
 
             Static data can also be prepended to the dynamic data.
 
-            >>> sample_pytorch_dataset.config.static_inclusion_mode = StaticInclusionMode.PREPEND
-            >>> sample_pytorch_dataset.config.seq_sampling_strategy = SubsequenceSamplingStrategy.TO_END
+            >>> sample_pytorch_dataset = MEDSPytorchDataset(
+            ...     dataclasses.replace(
+            ...         sample_pytorch_dataset.config,
+            ...         static_inclusion_mode=StaticInclusionMode.PREPEND,
+            ...         seq_sampling_strategy=SubsequenceSamplingStrategy.TO_END,
+            ...     ),
+            ...     split="train",
+            ... )
             >>> raw_batch = [sample_pytorch_dataset[2], sample_pytorch_dataset[3]]
             >>> print(sample_pytorch_dataset.collate(raw_batch))
             MEDSTorchBatch:
@@ -1530,8 +1557,14 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
 
             If the batch mode is SEM, the event mask will also be included and the output shape will differ:
 
-            >>> sample_pytorch_dataset.config.batch_mode = "SEM"
-            >>> sample_pytorch_dataset.config.static_inclusion_mode = StaticInclusionMode.OMIT
+            >>> sample_pytorch_dataset = MEDSPytorchDataset(
+            ...     dataclasses.replace(
+            ...         sample_pytorch_dataset.config,
+            ...         batch_mode="SEM",
+            ...         static_inclusion_mode=StaticInclusionMode.OMIT,
+            ...     ),
+            ...     split="train",
+            ... )
             >>> raw_batch = [sample_pytorch_dataset[2], sample_pytorch_dataset[3]]
             >>> print(sample_pytorch_dataset.collate(raw_batch))
             MEDSTorchBatch:
@@ -1581,7 +1614,11 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
 
             Padding side changes work in this mode as well.
 
-            >>> sample_pytorch_dataset.config.padding_side = "left"
+            >>> sample_pytorch_dataset = MEDSPytorchDataset(
+            ...     dataclasses.replace(sample_pytorch_dataset.config, padding_side="left"),
+            ...     split="train",
+            ... )
+            >>> raw_batch = [sample_pytorch_dataset[2], sample_pytorch_dataset[3]]
             >>> print(sample_pytorch_dataset.collate(raw_batch))
             MEDSTorchBatch:
             │ Mode: Subject-Event-Measurement (SEM)
@@ -1630,10 +1667,16 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
 
             In this mode, though redundant, the static mask will still be present if static data is prepended
 
-            >>> sample_pytorch_dataset.config.batch_mode = "SEM"
-            >>> sample_pytorch_dataset.config.padding_side = "right"
-            >>> sample_pytorch_dataset.config.static_inclusion_mode = StaticInclusionMode.PREPEND
-            >>> sample_pytorch_dataset.config.seq_sampling_strategy = SubsequenceSamplingStrategy.TO_END
+            >>> sample_pytorch_dataset = MEDSPytorchDataset(
+            ...     dataclasses.replace(
+            ...         sample_pytorch_dataset.config,
+            ...         batch_mode="SEM",
+            ...         padding_side="right",
+            ...         static_inclusion_mode=StaticInclusionMode.PREPEND,
+            ...         seq_sampling_strategy=SubsequenceSamplingStrategy.TO_END,
+            ...     ),
+            ...     split="train",
+            ... )
             >>> raw_batch = [sample_pytorch_dataset[2], sample_pytorch_dataset[3]]
             >>> print(sample_pytorch_dataset.collate(raw_batch))
             MEDSTorchBatch:
@@ -1697,21 +1740,28 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
 
             Baseline — both flags on:
 
-            >>> sample_pytorch_dataset.config.batch_mode = "SM"
-            >>> sample_pytorch_dataset.config.padding_side = "right"
-            >>> sample_pytorch_dataset.config.static_inclusion_mode = StaticInclusionMode.PREPEND
-            >>> sample_pytorch_dataset.config.seq_sampling_strategy = SubsequenceSamplingStrategy.TO_END
-            >>> sample_pytorch_dataset.config.include_numeric_value = True
-            >>> sample_pytorch_dataset.config.include_time_delta = True
-            >>> raw_batch = [sample_pytorch_dataset[2], sample_pytorch_dataset[3]]
-            >>> batch = sample_pytorch_dataset.collate(raw_batch)
+            >>> base_cfg = dataclasses.replace(
+            ...     sample_pytorch_dataset.config,
+            ...     batch_mode="SM",
+            ...     padding_side="right",
+            ...     static_inclusion_mode=StaticInclusionMode.PREPEND,
+            ...     seq_sampling_strategy=SubsequenceSamplingStrategy.TO_END,
+            ...     include_numeric_value=True,
+            ...     include_time_delta=True,
+            ... )
+            >>> pyd = MEDSPytorchDataset(base_cfg, split="train")
+            >>> raw_batch = [pyd[2], pyd[3]]
+            >>> batch = pyd.collate(raw_batch)
             >>> (batch.numeric_value is None, batch.numeric_value_mask is None, batch.time_delta_days is None)
             (False, False, False)
 
             `include_numeric_value=False` — numeric_value *and* its mask vanish:
 
-            >>> sample_pytorch_dataset.config.include_numeric_value = False
-            >>> batch = sample_pytorch_dataset.collate(raw_batch)
+            >>> pyd = MEDSPytorchDataset(
+            ...     dataclasses.replace(base_cfg, include_numeric_value=False), split="train"
+            ... )
+            >>> raw_batch = [pyd[2], pyd[3]]
+            >>> batch = pyd.collate(raw_batch)
             >>> (batch.numeric_value is None, batch.numeric_value_mask is None, batch.time_delta_days is None)
             (True, True, False)
 
@@ -1720,25 +1770,26 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
             silently disappears when that flag goes off; the current implementation reads
             the axis from `code` (always present), so the mask still has the right shape.
 
-            >>> sample_pytorch_dataset.config.include_numeric_value = True
-            >>> sample_pytorch_dataset.config.include_time_delta = False
-            >>> batch = sample_pytorch_dataset.collate(raw_batch)
+            >>> pyd = MEDSPytorchDataset(
+            ...     dataclasses.replace(base_cfg, include_time_delta=False), split="train"
+            ... )
+            >>> raw_batch = [pyd[2], pyd[3]]
+            >>> batch = pyd.collate(raw_batch)
             >>> (batch.numeric_value is None, batch.time_delta_days is None,
             ...  batch.static_mask.shape == batch.code.shape)
             (False, True, True)
 
             Both off together:
 
-            >>> sample_pytorch_dataset.config.include_numeric_value = False
-            >>> batch = sample_pytorch_dataset.collate(raw_batch)
+            >>> pyd = MEDSPytorchDataset(
+            ...     dataclasses.replace(base_cfg, include_numeric_value=False, include_time_delta=False),
+            ...     split="train",
+            ... )
+            >>> raw_batch = [pyd[2], pyd[3]]
+            >>> batch = pyd.collate(raw_batch)
             >>> (batch.numeric_value is None, batch.time_delta_days is None,
             ...  batch.static_mask.shape == batch.code.shape)
             (True, True, True)
-
-            Restore defaults so later doctests see both fields:
-
-            >>> sample_pytorch_dataset.config.include_numeric_value = True
-            >>> sample_pytorch_dataset.config.include_time_delta = True
         """
 
         data = JointNestedRaggedTensorDict.vstack([item["dynamic"] for item in batch])
@@ -1816,10 +1867,17 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
             torch.utils.data.DataLoader: A DataLoader object for this dataset.
 
         Examples:
+            >>> import dataclasses
             >>> from meds_torchdata.types import SubsequenceSamplingStrategy
-            >>> sample_pytorch_dataset.config.static_inclusion_mode = StaticInclusionMode.INCLUDE
-            >>> sample_pytorch_dataset.config.seq_sampling_strategy = SubsequenceSamplingStrategy.TO_END
-            >>> sample_pytorch_dataset.config.batch_mode = "SM"
+            >>> sample_pytorch_dataset = MEDSPytorchDataset(
+            ...     dataclasses.replace(
+            ...         sample_pytorch_dataset.config,
+            ...         static_inclusion_mode=StaticInclusionMode.INCLUDE,
+            ...         seq_sampling_strategy=SubsequenceSamplingStrategy.TO_END,
+            ...         batch_mode="SM",
+            ...     ),
+            ...     split="train",
+            ... )
             >>> _ = torch.manual_seed(0)
             >>> torch.use_deterministic_algorithms(True)
             >>> DL = sample_pytorch_dataset.get_dataloader(batch_size=2, shuffle=False)

--- a/src/meds_torchdata/pytorch_dataset.py
+++ b/src/meds_torchdata/pytorch_dataset.py
@@ -233,11 +233,9 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
     def __init__(self, cfg: MEDSTorchDataConfig, split: str):
         super().__init__()
 
-        # Lock the cfg against post-handoff mutation — see `MEDSTorchDataConfig.__setattr__`
-        # for the full rationale. `object.__setattr__` bypasses our own lock hook, which is
-        # the only way to set the sentinel itself. Idempotent: reusing the same cfg across
-        # multiple datasets just re-asserts the same flag.
-        object.__setattr__(cfg, "_handed_off_to_dataset", True)
+        # Lock the cfg against further mutation while it's attached to this dataset — see
+        # `MEDSTorchDataConfig.lock()` / `unlock()` for the full contract and escape hatch.
+        cfg.lock()
 
         self.config: MEDSTorchDataConfig = cfg
         self.split: str = split
@@ -1178,9 +1176,9 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
 
             In `StaticInclusionMode.OMIT` the static slot is returned as `None` rather than an
             empty `StaticData` — the static columns are never loaded from disk in that mode, so
-            there is genuinely nothing to surface. `MEDSTorchDataConfig` is frozen, so swap in
-            a modified config by constructing a fresh dataset (`dataclasses.replace` is the
-            idiomatic Python way to derive a new config with overrides):
+            there is genuinely nothing to surface. `sample_pytorch_dataset.config` is locked
+            (see `MEDSTorchDataConfig.lock()`), so swap in a modified config by deriving a new
+            one with `dataclasses.replace` and constructing a fresh dataset:
 
             >>> import dataclasses
             >>> omit_cfg = dataclasses.replace(

--- a/tests/test_pytorch_dataset_properties.py
+++ b/tests/test_pytorch_dataset_properties.py
@@ -1,3 +1,4 @@
+import dataclasses
 from datetime import datetime, timedelta
 
 import numpy as np
@@ -196,8 +197,7 @@ def test_get_task_seq_bounds_and_labels_unlabeled(data):
 @given(st.data())
 @settings(max_examples=25, deadline=None)
 def test_schema_df_last_observed(sample_dataset_config_with_index, data):
-    cfg = sample_dataset_config_with_index
-    cfg.include_window_last_observed_in_schema = True
+    cfg = dataclasses.replace(sample_dataset_config_with_index, include_window_last_observed_in_schema=True)
     dataset = MEDSPytorchDataset(cfg, split="train")
 
     idx = data.draw(st.integers(min_value=0, max_value=len(dataset) - 1))
@@ -244,9 +244,11 @@ def test_get_task_seq_bounds_and_labels_semantic(data):
 
 
 def test_getitem_consistency(sample_dataset_config_with_index):
-    cfg = sample_dataset_config_with_index
-    cfg.include_window_last_observed_in_schema = True
-    cfg.batch_mode = BatchMode.SEM
+    cfg = dataclasses.replace(
+        sample_dataset_config_with_index,
+        include_window_last_observed_in_schema=True,
+        batch_mode=BatchMode.SEM,
+    )
     dataset = MEDSPytorchDataset(cfg, split="train")
 
     for idx in range(len(dataset)):


### PR DESCRIPTION
## Summary

- `MEDSTorchDataConfig` stays a mutable `@dataclass`, but grows a `__setattr__` hook that raises `RuntimeError` with migration text once a `_handed_off_to_dataset` sentinel is set.
- `MEDSPytorchDataset.__init__` sets the sentinel via `object.__setattr__` on the incoming cfg — idempotent, zero-cost, bypasses our own lock hook.
- Pre-handoff: users build, tweak, and validate configs freely (no change from today).
- Post-handoff: `cfg.field = value` raises with text pointing at `dataclasses.replace(cfg, field=value)`. Exactly the #81 bug surface, caught with actionable guidance.

## Why this instead of `frozen=True`

The original draft used `@dataclass(frozen=True)`, which was more disruptive than necessary — every downstream user who mutates a config anywhere in their code would get a `FrozenInstanceError`. Per PR discussion, the lock-on-handoff approach preserves the common "build → hand off → done" ergonomics unchanged while still catching the silent-failure scenario (mutation after handoff where the change can't reach the dataset or its workers).

No deep copy needed: all current config fields are immutable primitives (`Path`, `int`, `bool`, enum, `None`), so there's no aliased-mutable-collection attack vector for deep-copy to protect against. The lock alone is sufficient.

## Motivation

The perf PRs that landed on `dev` (#106, #107) made #107's `persistent_workers=True` default auto-enable for `num_workers > 0`. Before that change, workers respawned each epoch, so `cfg.field = value` between epochs accidentally propagated via pickling a fresh dataset into new workers. After #107, workers persist across the run, so main-process mutations never reach worker copies — silent drift the user can't see from either side. The lock closes that surface.

Full analysis: [#81 update comment](https://github.com/mmcdermott/meds-torch-data/issues/81#issuecomment-4282139172).

## Test plan

- [x] `uv run pytest --no-cov tests/ src/ README.md` — 84 tests pass (one new doctest pinning the lock semantics)
- [x] `uv run pre-commit run` — clean
- [x] Doctest/test mutation sites migrated to `dataclasses.replace(cfg, field=value)` + fresh `MEDSPytorchDataset(cfg, ...)` — these were *exactly* the post-handoff mutation pattern the lock catches, so they still needed updating
- [ ] CI green on push

## Addresses #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)