### PR TITLE
Pre-RC polish: pin pickle-roundtrip of locked config

### DIFF
--- a/src/meds_torchdata/config.py
+++ b/src/meds_torchdata/config.py
@@ -566,6 +566,17 @@ class MEDSTorchDataConfig:
             Traceback (most recent call last):
                 ...
             RuntimeError: Cannot mutate `max_seq_len` on a locked MEDSTorchDataConfig...
+
+            The locked state round-trips through pickle — when `DataLoader(num_workers>0)`
+            pickles the dataset (and its config) into a worker process, the worker inherits
+            the lock. No stealthy mutation channel via pickle.
+
+            >>> import pickle
+            >>> restored = pickle.loads(pickle.dumps(cfg))
+            >>> restored.max_seq_len = 20
+            Traceback (most recent call last):
+                ...
+            RuntimeError: Cannot mutate `max_seq_len` on a locked MEDSTorchDataConfig...
         """
         object.__setattr__(self, "_locked", True)
 


### PR DESCRIPTION
## Summary

Pre-RC polish surfaced during review of the dev→main release candidate. Adds a doctest to `MEDSTorchDataConfig.lock()` verifying that the locked state round-trips through pickle — exactly the path `DataLoader(num_workers>0)` takes when spawning workers with `persistent_workers=True` (the default from #107).

Design was already correct (pickle preserves the `_locked` attribute in `__dict__`), but untested. This closes the test gap.

## Test plan

- [x] `uv run pytest --no-cov src/meds_torchdata/config.py` — 11 tests pass (one new doctest)
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)