### PR TITLE
Release candidate: dev → main (v0.9.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,16 @@ File path parameters include:
 - `tensorized_cohort_dir`: The directory containing the tensorized data.
 - `task_labels_dir`: The directory containing the task labels files.
 
+> [!NOTE]
+> A `MEDSTorchDataConfig` is freely mutable until you hand it to a `MEDSPytorchDataset`;
+> at that point the dataset calls `cfg.lock()` on it, and further `cfg.field = value`
+> mutations raise `RuntimeError` with a pointer to the fix. This catches the silent-failure
+> case where a post-handoff mutation would fail to propagate into the dataset (or into
+> worker processes under `persistent_workers=True`, the default for `num_workers > 0` via
+> `Datamodule`). To derive a modified config, use `dataclasses.replace(cfg, field=value)`
+> and construct a fresh `MEDSPytorchDataset` around it; `cfg.unlock()` is available as a
+> loudly-warned escape hatch for users who accept that the mutation will not propagate.
+
 It also provides a convenient property to get the vocab size for the dataset, given by the vocab indices in
 the tensorized metadata. Let's start by building a configuration object for this data and inspect some of its
 file-path related properties and helpers:
@@ -299,6 +309,7 @@ subject IDs and the end of the allowed region of reading for the dataset. We can
 format via the `schema_df`:
 
 ```python
+>>> import dataclasses
 >>> from meds_torchdata import MEDSPytorchDataset
 >>> cfg = MEDSTorchDataConfig(tensorized_cohort_dir=tensorized_MEDS_dataset, max_seq_len=5)
 >>> pyd = MEDSPytorchDataset(cfg, split="train")
@@ -542,8 +553,14 @@ This example shows what the output looks like if we set the static data inclusio
 we set it to `"prepend"` instead? To show this in a stable manner, we'll also use the seeded version of the
 get item function, `_seeded_getitem`:
 
+`pyd.config` is locked (`MEDSPytorchDataset` calls `cfg.lock()` on handoff);
+`dataclasses.replace` builds a new config with the override and we rebuild the
+dataset around it.
+
 ```python
->>> pyd.config.static_inclusion_mode = "prepend"
+>>> pyd = MEDSPytorchDataset(
+...     dataclasses.replace(pyd.config, static_inclusion_mode="prepend"), split="train"
+... )
 >>> print_element(pyd._seeded_getitem(2, seed=0))
 n_static_seq_els (int):
 2
@@ -556,7 +573,9 @@ numeric_value
 .
 time_delta_days
 [       nan        nan 0.         0.         0.09787037]
->>> pyd.config.static_inclusion_mode = "include"
+>>> pyd = MEDSPytorchDataset(
+...     dataclasses.replace(pyd.config, static_inclusion_mode="include"), split="train"
+... )
 
 ```
 
@@ -786,7 +805,9 @@ a separate entry in the batch. What about with the other two options, `"omit"` a
 If we use `"omit"`, we can see that the static data is omitted from the output:
 
 ```python
->>> pyd_with_task.config.static_inclusion_mode = "omit"
+>>> pyd_with_task = MEDSPytorchDataset(
+...     dataclasses.replace(pyd_with_task.config, static_inclusion_mode="omit"), split="train"
+... )
 >>> print(next(iter(pyd_with_task.get_dataloader(batch_size=2))))
 MEDSTorchBatch:
 │ Mode: Subject-Measurement (SM)
@@ -825,7 +846,9 @@ What if we use a static inclusion mode of `"prepend"`? We can see that the stati
 dynamic data:
 
 ```python
->>> pyd_with_task.config.static_inclusion_mode = "prepend"
+>>> pyd_with_task = MEDSPytorchDataset(
+...     dataclasses.replace(pyd_with_task.config, static_inclusion_mode="prepend"), split="train"
+... )
 >>> print(next(iter(pyd_with_task.get_dataloader(batch_size=2))))
 MEDSTorchBatch:
 │ Mode: Subject-Measurement (SM)
@@ -860,7 +883,10 @@ MEDSTorchBatch:
 │ │ Labels:
 │ │ │ boolean_value (torch.bool):
 │ │ │ │ [False,  True]
->>> pyd_with_task.config.static_inclusion_mode = "include" # reset to default
+>>> pyd_with_task = MEDSPytorchDataset(
+...     dataclasses.replace(pyd_with_task.config, static_inclusion_mode="include"),
+...     split="train",
+... )  # reset to default
 
 ```
 
@@ -869,7 +895,9 @@ default output to be at a _measurement_ level, rather than an _event_ level, by 
 `batch_mode` to `SM`. Let's see what happens if we change that:
 
 ```python
->>> pyd.config.batch_mode = "SEM"
+>>> pyd = MEDSPytorchDataset(
+...     dataclasses.replace(pyd.config, batch_mode="SEM"), split="train"
+... )
 >>> print_element(pyd[2])
 static_code (list):
 [8, 9]
@@ -953,7 +981,9 @@ MEDSTorchBatch:
 │ │ │ static_numeric_value_mask (torch.bool):
 │ │ │ │ [[False,  True],
 │ │ │ │  [False,  True]]
->>> pyd_with_task.config.batch_mode = "SEM"
+>>> pyd_with_task = MEDSPytorchDataset(
+...     dataclasses.replace(pyd_with_task.config, batch_mode="SEM"), split="train"
+... )
 >>> print(next(iter(pyd_with_task.get_dataloader(batch_size=2))))
 MEDSTorchBatch:
 │ Mode: Subject-Event-Measurement (SEM)
@@ -1022,7 +1052,9 @@ MEDSTorchBatch:
 │ │ Labels:
 │ │ │ boolean_value (torch.bool):
 │ │ │ │ [False,  True]
->>> pyd_with_task.config.static_inclusion_mode = "omit"
+>>> pyd_with_task = MEDSPytorchDataset(
+...     dataclasses.replace(pyd_with_task.config, static_inclusion_mode="omit"), split="train"
+... )
 >>> print(next(iter(pyd_with_task.get_dataloader(batch_size=2))))
 MEDSTorchBatch:
 │ Mode: Subject-Event-Measurement (SEM)
@@ -1079,7 +1111,9 @@ MEDSTorchBatch:
 │ │ Labels:
 │ │ │ boolean_value (torch.bool):
 │ │ │ │ [False,  True]
->>> pyd_with_task.config.static_inclusion_mode = "prepend"
+>>> pyd_with_task = MEDSPytorchDataset(
+...     dataclasses.replace(pyd_with_task.config, static_inclusion_mode="prepend"), split="train"
+... )
 >>> print(next(iter(pyd_with_task.get_dataloader(batch_size=2))))
 MEDSTorchBatch:
 │ Mode: Subject-Event-Measurement (SEM)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 dependencies = [
     "pytest",  # re-exported as a pytest plugin via `[project.entry-points.pytest11]`
     "polars>=1.30,<2",
-    "nested_ragged_tensors>=0.2,<0.3",
+    "nested_ragged_tensors>=0.3,<0.4",
     "numpy>=1.26,<3",
     "torch>=2.0",
     "meds>=0.4,<0.5",

--- a/src/meds_torchdata/config.py
+++ b/src/meds_torchdata/config.py
@@ -577,6 +577,19 @@ class MEDSTorchDataConfig:
             Traceback (most recent call last):
                 ...
             RuntimeError: Cannot mutate `max_seq_len` on a locked MEDSTorchDataConfig...
+
+            If `MEDSPytorchDataset.__init__` raises partway through (e.g., the caller asks
+            for a split that has no schema files), the lock is not applied — the caller is
+            free to fix up the cfg and retry without `unlock()`-ing first:
+
+            >>> cfg = MEDSTorchDataConfig(tensorized_cohort_dir=tensorized_MEDS_dataset, max_seq_len=5)
+            >>> try:
+            ...     MEDSPytorchDataset(cfg, split="nonexistent_split")
+            ... except FileNotFoundError:
+            ...     pass
+            >>> cfg.max_seq_len = 42  # no error, cfg is still mutable
+            >>> cfg.max_seq_len
+            42
         """
         object.__setattr__(self, "_locked", True)
 

--- a/src/meds_torchdata/config.py
+++ b/src/meds_torchdata/config.py
@@ -566,6 +566,17 @@ class MEDSTorchDataConfig:
             Traceback (most recent call last):
                 ...
             RuntimeError: Cannot mutate `max_seq_len` on a locked MEDSTorchDataConfig...
+
+            The locked state round-trips through pickle — when `DataLoader(num_workers>0)`
+            pickles the dataset (and its config) into a worker process, the worker inherits
+            the lock. No stealthy mutation channel via pickle.
+
+            >>> import pickle
+            >>> restored = pickle.loads(pickle.dumps(cfg))
+            >>> restored.max_seq_len = 20
+            Traceback (most recent call last):
+                ...
+            RuntimeError: Cannot mutate `max_seq_len` on a locked MEDSTorchDataConfig...
         """
         object.__setattr__(self, "_locked", True)
 

--- a/src/meds_torchdata/config.py
+++ b/src/meds_torchdata/config.py
@@ -533,6 +533,112 @@ class MEDSTorchDataConfig:
                     f"got strategy {self.seq_sampling_strategy} with overlap {self.step_through_overlap!r}."
                 )
 
+    def lock(self) -> None:
+        """Lock this config against further mutation.
+
+        Called automatically by `MEDSPytorchDataset.__init__` so the dataset can rely on
+        its config being stable across its lifetime — schema columns loaded, index
+        construction, JNRT cache keys, worker pickles. Idempotent; locking an already-locked
+        config is a no-op.
+
+        To mutate a locked config, either call `unlock()` first (with the caveat that the
+        change will not propagate into an already-attached dataset or its workers) or use
+        `dataclasses.replace(cfg, field=value)` to derive a new config.
+
+        Examples:
+            >>> from meds_torchdata import MEDSPytorchDataset, MEDSTorchDataConfig
+            >>> cfg = MEDSTorchDataConfig(tensorized_cohort_dir=tensorized_MEDS_dataset, max_seq_len=5)
+            >>> cfg.max_seq_len = 10  # mutable pre-lock
+            >>> cfg.max_seq_len
+            10
+            >>> cfg.lock()
+            >>> cfg.max_seq_len = 20
+            Traceback (most recent call last):
+                ...
+            RuntimeError: Cannot mutate `max_seq_len` on a locked MEDSTorchDataConfig...
+
+            `MEDSPytorchDataset.__init__` calls `lock()` on its input, so direct construction
+            produces the same locked state:
+
+            >>> cfg = MEDSTorchDataConfig(tensorized_cohort_dir=tensorized_MEDS_dataset, max_seq_len=5)
+            >>> pyd = MEDSPytorchDataset(cfg, split="train")
+            >>> cfg.max_seq_len = 20
+            Traceback (most recent call last):
+                ...
+            RuntimeError: Cannot mutate `max_seq_len` on a locked MEDSTorchDataConfig...
+        """
+        object.__setattr__(self, "_locked", True)
+
+    def unlock(self) -> None:
+        """Unlock a previously-locked config.
+
+        Emits a `UserWarning` when called on a currently-locked config — the typical
+        source of the lock is a `MEDSPytorchDataset` that has already captured the config's
+        state, so post-unlock mutations will not propagate into that dataset's
+        main-process view *or* its worker-process copies (which live on separate cfg
+        snapshots under `persistent_workers=True`, the default when `num_workers > 0`).
+        Users who explicitly want the escape hatch get it; they get a loud pointer at the
+        idiomatic alternative (`dataclasses.replace` + fresh `MEDSPytorchDataset`) too.
+
+        **Which fields can be mutated safely after unlock?** None of them in a
+        `num_workers > 0` DataLoader — workers pickle their own snapshot at spawn and
+        never see main-process mutations. In a **single-process** setting (`num_workers=0`,
+        direct `dataset[i]` access), the fields read fresh per hot-path call — and thus
+        safe to flip — are `padding_side`, `include_numeric_value`, `include_time_delta`,
+        `include_subject_window_counts_in_batch`, and `max_seq_len` when
+        `seq_sampling_strategy != STEP_THROUGH`. Every other field (sampling strategy,
+        batch mode, static mode, task labels dir, step-through params, window-last-observed,
+        tensorized cohort dir) is baked into dataset init state and flipping it
+        post-handoff leaves the dataset in an inconsistent state. For those, use
+        `dataclasses.replace(cfg, field=value)` + construct a fresh dataset instead.
+
+        Examples:
+            >>> import warnings
+            >>> cfg = MEDSTorchDataConfig(tensorized_cohort_dir=tensorized_MEDS_dataset, max_seq_len=5)
+            >>> cfg.lock()
+            >>> with warnings.catch_warnings(record=True) as caught:
+            ...     warnings.simplefilter("always")
+            ...     cfg.unlock()
+            ...     print(len(caught), caught[0].category.__name__)
+            1 UserWarning
+            >>> cfg.max_seq_len = 99  # mutable again
+            >>> cfg.max_seq_len
+            99
+
+            Calling `unlock()` on an already-unlocked config is a silent no-op:
+
+            >>> with warnings.catch_warnings(record=True) as caught:
+            ...     warnings.simplefilter("always")
+            ...     cfg.unlock()
+            ...     print(len(caught))
+            0
+        """
+        if getattr(self, "_locked", False):
+            import warnings
+
+            warnings.warn(
+                "Unlocking a locked MEDSTorchDataConfig. If this config is attached to a "
+                "MEDSPytorchDataset, post-unlock mutations will not propagate into the "
+                "dataset's main-process state or its worker-process copies. Prefer "
+                "`dataclasses.replace(cfg, field=value)` and constructing a fresh "
+                "MEDSPytorchDataset.",
+                stacklevel=2,
+            )
+        object.__setattr__(self, "_locked", False)
+
+    def __setattr__(self, key: str, value) -> None:
+        if getattr(self, "_locked", False):
+            raise RuntimeError(
+                f"Cannot mutate `{key}` on a locked MEDSTorchDataConfig. The lock is set "
+                "automatically when the config is handed to `MEDSPytorchDataset`, because "
+                "the dataset captures its state at init time and mutations here would not "
+                "propagate (and would not reach worker processes under "
+                "`persistent_workers=True`). Either call `cfg.unlock()` first (accepting "
+                "that caveat) or use `dataclasses.replace(cfg, "
+                f"{key}=...)` to derive a new config and construct a fresh dataset."
+            )
+        object.__setattr__(self, key, value)
+
     @property
     def code_metadata_fp(self) -> Path:
         """Return the code metadata file for this cohort.

--- a/src/meds_torchdata/config.py
+++ b/src/meds_torchdata/config.py
@@ -6,7 +6,7 @@ enumeration objects for categorical options and a general DataClass configuratio
 
 import logging
 from collections.abc import Generator
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from functools import cached_property
 from pathlib import Path
 
@@ -590,6 +590,18 @@ class MEDSTorchDataConfig:
             >>> cfg.max_seq_len = 42  # no error, cfg is still mutable
             >>> cfg.max_seq_len
             42
+
+            The error message differentiates by whether the attempted key is a real
+            config field. Typos / non-declared attributes get a dedicated message that
+            doesn't recommend `dataclasses.replace` (which would reject the bad key):
+
+            >>> cfg = MEDSTorchDataConfig(tensorized_cohort_dir=tensorized_MEDS_dataset, max_seq_len=5)
+            >>> cfg.lock()
+            >>> cfg.maks_seq_len = 10
+            Traceback (most recent call last):
+                ...
+            RuntimeError: Cannot set `maks_seq_len` on a locked MEDSTorchDataConfig:
+            `maks_seq_len` is not a declared field...
         """
         object.__setattr__(self, "_locked", True)
 
@@ -652,14 +664,27 @@ class MEDSTorchDataConfig:
 
     def __setattr__(self, key: str, value) -> None:
         if getattr(self, "_locked", False):
+            # Branch on whether the key is a real dataclass field. `dataclasses.replace`
+            # only accepts declared fields, so recommending it for a typo / ad-hoc attribute
+            # would produce a `TypeError: __init__() got an unexpected keyword argument`
+            # when the user tried to follow our guidance.
+            if key in {f.name for f in fields(self)}:
+                raise RuntimeError(
+                    f"Cannot mutate `{key}` on a locked MEDSTorchDataConfig. The lock is "
+                    "set automatically when the config is handed to `MEDSPytorchDataset`, "
+                    "because the dataset captures its state at init time and mutations "
+                    "here would not propagate (and would not reach worker processes under "
+                    "`persistent_workers=True`). Either call `cfg.unlock()` first "
+                    "(accepting that caveat) or use "
+                    f"`dataclasses.replace(cfg, {key}=...)` to derive a new config and "
+                    "construct a fresh dataset."
+                )
             raise RuntimeError(
-                f"Cannot mutate `{key}` on a locked MEDSTorchDataConfig. The lock is set "
-                "automatically when the config is handed to `MEDSPytorchDataset`, because "
-                "the dataset captures its state at init time and mutations here would not "
-                "propagate (and would not reach worker processes under "
-                "`persistent_workers=True`). Either call `cfg.unlock()` first (accepting "
-                "that caveat) or use `dataclasses.replace(cfg, "
-                f"{key}=...)` to derive a new config and construct a fresh dataset."
+                f"Cannot set `{key}` on a locked MEDSTorchDataConfig: `{key}` is not a "
+                "declared field on this class (did you mean to mutate a real config "
+                f"field, or is this a typo?). Valid fields: "
+                f"{sorted(f.name for f in fields(self))}. If you're intentionally "
+                "adding a dynamic attribute on the instance, call `cfg.unlock()` first."
             )
         object.__setattr__(self, key, value)
 

--- a/src/meds_torchdata/extensions/lightning_datamodule.py
+++ b/src/meds_torchdata/extensions/lightning_datamodule.py
@@ -28,7 +28,17 @@ class Datamodule(L.LightningDataModule, Generic[DatasetT]):
     Attributes:
         config: The configuration for the dataset.
         batch_size: The batch size for the dataloaders. Defaults to 32.
-        num_workers: The number of workers for the dataloaders. Defaults to 0.
+        num_workers: The number of workers for the dataloaders. Defaults to `None` (PyTorch's
+            `num_workers=0`); no safe universal default exists, so this is always user-supplied.
+        pin_memory: Whether to allocate batches in page-locked memory for faster GPU transfer.
+            Defaults to `None` (PyTorch's `False`); CUDA-detection auto-enabling is brittle
+            across MPS/ROCm/CPU, so this is left for the user.
+        persistent_workers: Whether workers persist across epochs. Defaults to `True` when
+            `num_workers > 0` (strict improvement — avoids re-spawning workers and re-running
+            `MEDSPytorchDataset.__init__` each epoch at the cost of keeping worker RSS alive).
+            Set `False` to opt out.
+        prefetch_factor: Number of batches prefetched by each worker. Defaults to `None`
+            (PyTorch's built-in default of 2). Raising helps on slow storage.
 
     Examples:
         >>> D = Datamodule(config=sample_dataset_config, batch_size=2)
@@ -58,14 +68,33 @@ class Datamodule(L.LightningDataModule, Generic[DatasetT]):
         MEDSTorchBatch(code=tensor([[ 5,  3, 10, 11,  4]]), ..., n_subject_windows=None)
 
     You can also set the number of workers to a non-zero value, and it will be applied to the created
-    dataloaders, along with batch size, through the `shared_dataloader_kwargs` property.
+    dataloaders, along with batch size, through the `shared_dataloader_kwargs` property. When
+    `num_workers > 0`, `persistent_workers` defaults to `True` so workers survive across epochs
+    and avoid re-running `MEDSPytorchDataset.__init__` (schema reads, index build) each epoch.
 
         >>> D = Datamodule(config=sample_dataset_config, batch_size=1, num_workers=4)
         >>> D.shared_dataloader_kwargs
-        {'batch_size': 1, 'num_workers': 4}
+        {'batch_size': 1, 'num_workers': 4, 'persistent_workers': True}
         >>> test_dataloader = D.test_dataloader()
         >>> next(iter(test_dataloader))
         MEDSTorchBatch(code=tensor([[ 5,  2, 10, 11, 10, 11, 10, 11,  4]]), ..., n_subject_windows=None)
+
+    Pass `persistent_workers=False` to opt out of the auto-enable — useful for constrained-memory
+    settings where releasing worker RSS between epochs matters more than per-epoch spawn cost.
+
+        >>> D = Datamodule(
+        ...     config=sample_dataset_config, batch_size=1, num_workers=4,
+        ...     persistent_workers=False,
+        ... )
+        >>> D.shared_dataloader_kwargs
+        {'batch_size': 1, 'num_workers': 4, 'persistent_workers': False}
+
+    With `num_workers=0` (or unset), `persistent_workers` isn't auto-populated — PyTorch rejects
+    `persistent_workers=True` without active workers.
+
+        >>> D = Datamodule(config=sample_dataset_config, batch_size=1)
+        >>> D.shared_dataloader_kwargs
+        {'batch_size': 1}
 
     You can also set the pin_memory flag to True, and it will be applied to the created dataloaders.
 
@@ -75,6 +104,15 @@ class Datamodule(L.LightningDataModule, Generic[DatasetT]):
         >>> test_dataloader = D.test_dataloader()
         >>> next(iter(test_dataloader))
         MEDSTorchBatch(code=tensor([[ 5,  2, 10, 11, 10, 11, 10, 11,  4]]), ..., n_subject_windows=None)
+
+    `prefetch_factor` is a pass-through — PyTorch's default of 2 is fine for most users, but
+    slow storage can benefit from raising it. Only takes effect when `num_workers > 0`.
+
+        >>> D = Datamodule(
+        ...     config=sample_dataset_config, batch_size=1, num_workers=2, prefetch_factor=4,
+        ... )
+        >>> D.shared_dataloader_kwargs
+        {'batch_size': 1, 'num_workers': 2, 'prefetch_factor': 4, 'persistent_workers': True}
 
     You can also override the dataset class used by the datamodule via the `data_class` argument. This is
     useful for injecting convenience helpers or light instrumentation while retaining the core
@@ -112,6 +150,8 @@ class Datamodule(L.LightningDataModule, Generic[DatasetT]):
     batch_size: int
     num_workers: int | None
     pin_memory: bool | None = None
+    persistent_workers: bool | None = None
+    prefetch_factor: int | None = None
 
     def __init__(
         self,
@@ -120,6 +160,8 @@ class Datamodule(L.LightningDataModule, Generic[DatasetT]):
         batch_size: int = 32,
         num_workers: int | None = None,
         pin_memory: bool | None = None,
+        persistent_workers: bool | None = None,
+        prefetch_factor: int | None = None,
     ):
         super().__init__()
         self.config = config
@@ -129,12 +171,16 @@ class Datamodule(L.LightningDataModule, Generic[DatasetT]):
         self.batch_size = batch_size
         self.num_workers = num_workers
         self.pin_memory = pin_memory
+        self.persistent_workers = persistent_workers
+        self.prefetch_factor = prefetch_factor
 
         self.save_hyperparameters(
             {
                 "batch_size": batch_size,
                 "num_workers": num_workers,
                 "pin_memory": pin_memory,
+                "persistent_workers": persistent_workers,
+                "prefetch_factor": prefetch_factor,
                 "config": dataclasses.asdict(config),
             }
         )
@@ -142,9 +188,19 @@ class Datamodule(L.LightningDataModule, Generic[DatasetT]):
     @property
     def shared_dataloader_kwargs(self) -> dict:
         out = {"batch_size": self.batch_size}
-        for param in {"num_workers", "pin_memory"}:
+        for param in ("num_workers", "pin_memory", "prefetch_factor"):
             if getattr(self, param) is not None:
                 out[param] = getattr(self, param)
+        # `persistent_workers` defaults to `True` whenever workers are active. Saves the
+        # worker-spawn + `MEDSPytorchDataset.__init__` cost (schema reads, index build) per
+        # epoch. Cost is purely memory retention across epochs, which for MTD is already
+        # bounded by the per-worker `schema_dfs_by_shard` copy. PyTorch errors on
+        # `persistent_workers=True` when `num_workers=0`, so only auto-enable when workers
+        # are active; an explicit user value always wins.
+        if self.persistent_workers is not None:
+            out["persistent_workers"] = self.persistent_workers
+        elif self.num_workers is not None and self.num_workers > 0:
+            out["persistent_workers"] = True
         return out
 
     @cached_property

--- a/src/meds_torchdata/extensions/lightning_datamodule.py
+++ b/src/meds_torchdata/extensions/lightning_datamodule.py
@@ -106,8 +106,13 @@ class Datamodule(L.LightningDataModule, Generic[DatasetT]):
         MEDSTorchBatch(code=tensor([[ 5,  2, 10, 11, 10, 11, 10, 11,  4]]), ..., n_subject_windows=None)
 
     `prefetch_factor` is a pass-through — PyTorch's default of 2 is fine for most users, but
-    slow storage can benefit from raising it. Only takes effect when `num_workers > 0`.
+    slow storage can benefit from raising it. Only takes effect when `num_workers > 0`;
+    passed-through values are dropped otherwise (PyTorch rejects `prefetch_factor` without
+    active workers).
 
+        >>> D = Datamodule(config=sample_dataset_config, batch_size=1, prefetch_factor=4)
+        >>> D.shared_dataloader_kwargs
+        {'batch_size': 1}
         >>> D = Datamodule(
         ...     config=sample_dataset_config, batch_size=1, num_workers=2, prefetch_factor=4,
         ... )
@@ -188,18 +193,22 @@ class Datamodule(L.LightningDataModule, Generic[DatasetT]):
     @property
     def shared_dataloader_kwargs(self) -> dict:
         out = {"batch_size": self.batch_size}
-        for param in ("num_workers", "pin_memory", "prefetch_factor"):
+        for param in ("num_workers", "pin_memory"):
             if getattr(self, param) is not None:
                 out[param] = getattr(self, param)
+        workers_active = self.num_workers is not None and self.num_workers > 0
+        # `prefetch_factor` is meaningless without workers (PyTorch errors if passed with
+        # `num_workers=0`). Silently drop rather than forwarding an invalid combination.
+        if self.prefetch_factor is not None and workers_active:
+            out["prefetch_factor"] = self.prefetch_factor
         # `persistent_workers` defaults to `True` whenever workers are active. Saves the
         # worker-spawn + `MEDSPytorchDataset.__init__` cost (schema reads, index build) per
         # epoch. Cost is purely memory retention across epochs, which for MTD is already
-        # bounded by the per-worker `schema_dfs_by_shard` copy. PyTorch errors on
-        # `persistent_workers=True` when `num_workers=0`, so only auto-enable when workers
-        # are active; an explicit user value always wins.
+        # bounded by the per-worker `schema_dfs_by_shard` copy. An explicit user value
+        # wins; PyTorch raises a clear error for the invalid `True + num_workers=0` combo.
         if self.persistent_workers is not None:
             out["persistent_workers"] = self.persistent_workers
-        elif self.num_workers is not None and self.num_workers > 0:
+        elif workers_active:
             out["persistent_workers"] = True
         return out
 

--- a/src/meds_torchdata/pytorch_dataset.py
+++ b/src/meds_torchdata/pytorch_dataset.py
@@ -26,8 +26,10 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
     Key design principles:
       1. The class will store an `index` variable that specifies what is the valid range of data to consider
          for any given subject in the dataset corresponding to an integer index passed to `__getitem__`.
-      2. Data will only be loaded for subjects on an as-needed basis, and will not be cached, to minimize
-         memory usage during normal operation.
+      2. Subject tensor data is loaded on an as-needed basis and is not cached, to minimize memory
+         usage during normal operation. (JNRT *handles* are memoized per `(shard, load_keys)` on
+         `self._jnrt_cache` to avoid rebuilding the handle object on every `__getitem__` — this
+         is a Python-level wrapper cache, not a cache of the underlying tensor bytes.)
       3. As much work as possible should be relegated to separate dataset pre-processing (resulting in files
          stored on disk) rather than this class to streamline operation.
       4. The primary input to this class in terms of data is a pre-processed set of "schema files" and "nested

--- a/src/meds_torchdata/pytorch_dataset.py
+++ b/src/meds_torchdata/pytorch_dataset.py
@@ -233,10 +233,6 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
     def __init__(self, cfg: MEDSTorchDataConfig, split: str):
         super().__init__()
 
-        # Lock the cfg against further mutation while it's attached to this dataset — see
-        # `MEDSTorchDataConfig.lock()` / `unlock()` for the full contract and escape hatch.
-        cfg.lock()
-
         self.config: MEDSTorchDataConfig = cfg
         self.split: str = split
 
@@ -335,6 +331,12 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
         # (another optional tensor, mode-specific file selection, etc.), the cache key
         # must expand to match — otherwise stale entries will be served.
         self._jnrt_cache: dict[tuple[str, frozenset[str]], JointNestedRaggedTensorDict] = {}
+
+        # Lock the cfg only after init has fully succeeded — if any of the above raises
+        # (missing schema, column mismatch, etc.), the caller keeps a mutable cfg and can
+        # retry or modify without having to `unlock()` first. See `MEDSTorchDataConfig.lock()`
+        # / `unlock()` for the full contract and escape hatch.
+        cfg.lock()
 
     def __getstate__(self) -> dict:
         state = self.__dict__.copy()

--- a/src/meds_torchdata/pytorch_dataset.py
+++ b/src/meds_torchdata/pytorch_dataset.py
@@ -318,19 +318,22 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
 
         # JNRT handle cache — avoids rebuilding the handle object on every `__getitem__`.
         # Keyed by `(shard, frozenset(load_keys))` so a runtime flip of
-        # `config.include_numeric_value` / `include_time_delta` naturally invalidates.
+        # `config.include_numeric_value` / `config.include_time_delta` naturally invalidates.
         # Dropped on pickle (see `__getstate__`) so `DataLoader(num_workers>0)` workers
         # rebuild their own cache rather than trying to serialize a safetensors handle
         # that doesn't round-trip through pickle.
+        #
+        # Maintenance contract: this key assumes the dynamic view returned by
+        # `load_subject_data` is fully determined by `(shard, load_keys)`. If a future
+        # change makes the file path or the loaded view depend on additional config state
+        # (another optional tensor, mode-specific file selection, etc.), the cache key
+        # must expand to match — otherwise stale entries will be served.
         self._jnrt_cache: dict[tuple[str, frozenset[str]], JointNestedRaggedTensorDict] = {}
 
     def __getstate__(self) -> dict:
         state = self.__dict__.copy()
         state["_jnrt_cache"] = {}
         return state
-
-    def __setstate__(self, state: dict) -> None:
-        self.__dict__.update(state)
 
     def _expand_index_for_step_through(self) -> None:
         """Expand `self.index` so that STEP_THROUGH sampling produces one entry per window.
@@ -1175,9 +1178,9 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
             True
             >>> sample_pytorch_dataset.config.static_inclusion_mode = StaticInclusionMode.INCLUDE
 
-            The JNRT handle is cached per `(shard, load_keys)` on the dataset instance, so
-            repeated calls that hit the same shard reuse one handle rather than rebuilding
-            the safetensors wrapper each time:
+            The JNRT handle is cached per `(shard, frozenset(load_keys))` on the dataset
+            instance, so repeated calls that hit the same shard reuse one handle rather
+            than rebuilding the safetensors wrapper each time:
 
             >>> cfg = MEDSTorchDataConfig(tensorized_cohort_dir=tensorized_MEDS_dataset, max_seq_len=5)
             >>> fresh = MEDSPytorchDataset(cfg, split="train")

--- a/src/meds_torchdata/pytorch_dataset.py
+++ b/src/meds_torchdata/pytorch_dataset.py
@@ -233,6 +233,10 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
     def __init__(self, cfg: MEDSTorchDataConfig, split: str):
         super().__init__()
 
+        # Lock the cfg against further mutation while it's attached to this dataset — see
+        # `MEDSTorchDataConfig.lock()` / `unlock()` for the full contract and escape hatch.
+        cfg.lock()
+
         self.config: MEDSTorchDataConfig = cfg
         self.split: str = split
 
@@ -1172,13 +1176,18 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
 
             In `StaticInclusionMode.OMIT` the static slot is returned as `None` rather than an
             empty `StaticData` — the static columns are never loaded from disk in that mode, so
-            there is genuinely nothing to surface:
+            there is genuinely nothing to surface. `sample_pytorch_dataset.config` is locked
+            (see `MEDSTorchDataConfig.lock()`), so swap in a modified config by deriving a new
+            one with `dataclasses.replace` and constructing a fresh dataset:
 
-            >>> sample_pytorch_dataset.config.static_inclusion_mode = StaticInclusionMode.OMIT
-            >>> _, static_data = sample_pytorch_dataset.load_subject_data(68729, 0, 3)
+            >>> import dataclasses
+            >>> omit_cfg = dataclasses.replace(
+            ...     sample_pytorch_dataset.config, static_inclusion_mode=StaticInclusionMode.OMIT
+            ... )
+            >>> omit_pyd = MEDSPytorchDataset(omit_cfg, split="train")
+            >>> _, static_data = omit_pyd.load_subject_data(68729, 0, 3)
             >>> static_data is None
             True
-            >>> sample_pytorch_dataset.config.static_inclusion_mode = StaticInclusionMode.INCLUDE
 
             The JNRT handle is cached per `(shard, frozenset(load_keys))` on the dataset
             instance, so repeated calls that hit the same shard reuse one handle rather
@@ -1350,9 +1359,16 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
             you can set it to "left" for generative use cases. To show this, we'll also set the sampling
             strategy to `SubsequenceSamplingStrategy.TO_END` so that things are consistent.
 
+            >>> import dataclasses
             >>> from meds_torchdata.types import SubsequenceSamplingStrategy
-            >>> sample_pytorch_dataset.config.padding_side = "left"
-            >>> sample_pytorch_dataset.config.seq_sampling_strategy = SubsequenceSamplingStrategy.TO_END
+            >>> sample_pytorch_dataset = MEDSPytorchDataset(
+            ...     dataclasses.replace(
+            ...         sample_pytorch_dataset.config,
+            ...         padding_side="left",
+            ...         seq_sampling_strategy=SubsequenceSamplingStrategy.TO_END,
+            ...     ),
+            ...     split="train",
+            ... )
             >>> raw_batch = [sample_pytorch_dataset[i] for i in range(len(sample_pytorch_dataset))]
             >>> print(sample_pytorch_dataset.collate(raw_batch))
             MEDSTorchBatch:
@@ -1406,7 +1422,10 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
             │ │ │ │  [False,  True],
             │ │ │ │  [False,  True],
             │ │ │ │  [False,  True]]
-            >>> sample_pytorch_dataset.config.padding_side = "right"
+            >>> sample_pytorch_dataset = MEDSPytorchDataset(
+            ...     dataclasses.replace(sample_pytorch_dataset.config, padding_side="right"),
+            ...     split="train",
+            ... )
             >>> raw_batch = [sample_pytorch_dataset[i] for i in range(len(sample_pytorch_dataset))]
             >>> print(sample_pytorch_dataset.collate(raw_batch))
             MEDSTorchBatch:
@@ -1463,8 +1482,14 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
 
             Static data can also be omitted if set in the config.
 
-            >>> sample_pytorch_dataset.config.static_inclusion_mode = StaticInclusionMode.OMIT
-            >>> sample_pytorch_dataset.config.seq_sampling_strategy = SubsequenceSamplingStrategy.RANDOM
+            >>> sample_pytorch_dataset = MEDSPytorchDataset(
+            ...     dataclasses.replace(
+            ...         sample_pytorch_dataset.config,
+            ...         static_inclusion_mode=StaticInclusionMode.OMIT,
+            ...         seq_sampling_strategy=SubsequenceSamplingStrategy.RANDOM,
+            ...     ),
+            ...     split="train",
+            ... )
             >>> raw_batch = [sample_pytorch_dataset[2], sample_pytorch_dataset[3]]
             >>> print(sample_pytorch_dataset.collate(raw_batch))
             MEDSTorchBatch:
@@ -1495,8 +1520,14 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
 
             Static data can also be prepended to the dynamic data.
 
-            >>> sample_pytorch_dataset.config.static_inclusion_mode = StaticInclusionMode.PREPEND
-            >>> sample_pytorch_dataset.config.seq_sampling_strategy = SubsequenceSamplingStrategy.TO_END
+            >>> sample_pytorch_dataset = MEDSPytorchDataset(
+            ...     dataclasses.replace(
+            ...         sample_pytorch_dataset.config,
+            ...         static_inclusion_mode=StaticInclusionMode.PREPEND,
+            ...         seq_sampling_strategy=SubsequenceSamplingStrategy.TO_END,
+            ...     ),
+            ...     split="train",
+            ... )
             >>> raw_batch = [sample_pytorch_dataset[2], sample_pytorch_dataset[3]]
             >>> print(sample_pytorch_dataset.collate(raw_batch))
             MEDSTorchBatch:
@@ -1530,8 +1561,14 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
 
             If the batch mode is SEM, the event mask will also be included and the output shape will differ:
 
-            >>> sample_pytorch_dataset.config.batch_mode = "SEM"
-            >>> sample_pytorch_dataset.config.static_inclusion_mode = StaticInclusionMode.OMIT
+            >>> sample_pytorch_dataset = MEDSPytorchDataset(
+            ...     dataclasses.replace(
+            ...         sample_pytorch_dataset.config,
+            ...         batch_mode="SEM",
+            ...         static_inclusion_mode=StaticInclusionMode.OMIT,
+            ...     ),
+            ...     split="train",
+            ... )
             >>> raw_batch = [sample_pytorch_dataset[2], sample_pytorch_dataset[3]]
             >>> print(sample_pytorch_dataset.collate(raw_batch))
             MEDSTorchBatch:
@@ -1581,7 +1618,11 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
 
             Padding side changes work in this mode as well.
 
-            >>> sample_pytorch_dataset.config.padding_side = "left"
+            >>> sample_pytorch_dataset = MEDSPytorchDataset(
+            ...     dataclasses.replace(sample_pytorch_dataset.config, padding_side="left"),
+            ...     split="train",
+            ... )
+            >>> raw_batch = [sample_pytorch_dataset[2], sample_pytorch_dataset[3]]
             >>> print(sample_pytorch_dataset.collate(raw_batch))
             MEDSTorchBatch:
             │ Mode: Subject-Event-Measurement (SEM)
@@ -1630,10 +1671,16 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
 
             In this mode, though redundant, the static mask will still be present if static data is prepended
 
-            >>> sample_pytorch_dataset.config.batch_mode = "SEM"
-            >>> sample_pytorch_dataset.config.padding_side = "right"
-            >>> sample_pytorch_dataset.config.static_inclusion_mode = StaticInclusionMode.PREPEND
-            >>> sample_pytorch_dataset.config.seq_sampling_strategy = SubsequenceSamplingStrategy.TO_END
+            >>> sample_pytorch_dataset = MEDSPytorchDataset(
+            ...     dataclasses.replace(
+            ...         sample_pytorch_dataset.config,
+            ...         batch_mode="SEM",
+            ...         padding_side="right",
+            ...         static_inclusion_mode=StaticInclusionMode.PREPEND,
+            ...         seq_sampling_strategy=SubsequenceSamplingStrategy.TO_END,
+            ...     ),
+            ...     split="train",
+            ... )
             >>> raw_batch = [sample_pytorch_dataset[2], sample_pytorch_dataset[3]]
             >>> print(sample_pytorch_dataset.collate(raw_batch))
             MEDSTorchBatch:
@@ -1697,21 +1744,28 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
 
             Baseline — both flags on:
 
-            >>> sample_pytorch_dataset.config.batch_mode = "SM"
-            >>> sample_pytorch_dataset.config.padding_side = "right"
-            >>> sample_pytorch_dataset.config.static_inclusion_mode = StaticInclusionMode.PREPEND
-            >>> sample_pytorch_dataset.config.seq_sampling_strategy = SubsequenceSamplingStrategy.TO_END
-            >>> sample_pytorch_dataset.config.include_numeric_value = True
-            >>> sample_pytorch_dataset.config.include_time_delta = True
-            >>> raw_batch = [sample_pytorch_dataset[2], sample_pytorch_dataset[3]]
-            >>> batch = sample_pytorch_dataset.collate(raw_batch)
+            >>> base_cfg = dataclasses.replace(
+            ...     sample_pytorch_dataset.config,
+            ...     batch_mode="SM",
+            ...     padding_side="right",
+            ...     static_inclusion_mode=StaticInclusionMode.PREPEND,
+            ...     seq_sampling_strategy=SubsequenceSamplingStrategy.TO_END,
+            ...     include_numeric_value=True,
+            ...     include_time_delta=True,
+            ... )
+            >>> pyd = MEDSPytorchDataset(base_cfg, split="train")
+            >>> raw_batch = [pyd[2], pyd[3]]
+            >>> batch = pyd.collate(raw_batch)
             >>> (batch.numeric_value is None, batch.numeric_value_mask is None, batch.time_delta_days is None)
             (False, False, False)
 
             `include_numeric_value=False` — numeric_value *and* its mask vanish:
 
-            >>> sample_pytorch_dataset.config.include_numeric_value = False
-            >>> batch = sample_pytorch_dataset.collate(raw_batch)
+            >>> pyd = MEDSPytorchDataset(
+            ...     dataclasses.replace(base_cfg, include_numeric_value=False), split="train"
+            ... )
+            >>> raw_batch = [pyd[2], pyd[3]]
+            >>> batch = pyd.collate(raw_batch)
             >>> (batch.numeric_value is None, batch.numeric_value_mask is None, batch.time_delta_days is None)
             (True, True, False)
 
@@ -1720,25 +1774,26 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
             silently disappears when that flag goes off; the current implementation reads
             the axis from `code` (always present), so the mask still has the right shape.
 
-            >>> sample_pytorch_dataset.config.include_numeric_value = True
-            >>> sample_pytorch_dataset.config.include_time_delta = False
-            >>> batch = sample_pytorch_dataset.collate(raw_batch)
+            >>> pyd = MEDSPytorchDataset(
+            ...     dataclasses.replace(base_cfg, include_time_delta=False), split="train"
+            ... )
+            >>> raw_batch = [pyd[2], pyd[3]]
+            >>> batch = pyd.collate(raw_batch)
             >>> (batch.numeric_value is None, batch.time_delta_days is None,
             ...  batch.static_mask.shape == batch.code.shape)
             (False, True, True)
 
             Both off together:
 
-            >>> sample_pytorch_dataset.config.include_numeric_value = False
-            >>> batch = sample_pytorch_dataset.collate(raw_batch)
+            >>> pyd = MEDSPytorchDataset(
+            ...     dataclasses.replace(base_cfg, include_numeric_value=False, include_time_delta=False),
+            ...     split="train",
+            ... )
+            >>> raw_batch = [pyd[2], pyd[3]]
+            >>> batch = pyd.collate(raw_batch)
             >>> (batch.numeric_value is None, batch.time_delta_days is None,
             ...  batch.static_mask.shape == batch.code.shape)
             (True, True, True)
-
-            Restore defaults so later doctests see both fields:
-
-            >>> sample_pytorch_dataset.config.include_numeric_value = True
-            >>> sample_pytorch_dataset.config.include_time_delta = True
         """
 
         data = JointNestedRaggedTensorDict.vstack([item["dynamic"] for item in batch])
@@ -1816,10 +1871,17 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
             torch.utils.data.DataLoader: A DataLoader object for this dataset.
 
         Examples:
+            >>> import dataclasses
             >>> from meds_torchdata.types import SubsequenceSamplingStrategy
-            >>> sample_pytorch_dataset.config.static_inclusion_mode = StaticInclusionMode.INCLUDE
-            >>> sample_pytorch_dataset.config.seq_sampling_strategy = SubsequenceSamplingStrategy.TO_END
-            >>> sample_pytorch_dataset.config.batch_mode = "SM"
+            >>> sample_pytorch_dataset = MEDSPytorchDataset(
+            ...     dataclasses.replace(
+            ...         sample_pytorch_dataset.config,
+            ...         static_inclusion_mode=StaticInclusionMode.INCLUDE,
+            ...         seq_sampling_strategy=SubsequenceSamplingStrategy.TO_END,
+            ...         batch_mode="SM",
+            ...     ),
+            ...     split="train",
+            ... )
             >>> _ = torch.manual_seed(0)
             >>> torch.use_deterministic_algorithms(True)
             >>> DL = sample_pytorch_dataset.get_dataloader(batch_size=2, shuffle=False)

--- a/src/meds_torchdata/pytorch_dataset.py
+++ b/src/meds_torchdata/pytorch_dataset.py
@@ -316,17 +316,17 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
         if self.config.seq_sampling_strategy == SubsequenceSamplingStrategy.STEP_THROUGH:
             self._expand_index_for_step_through()
 
-        # Per-shard JNRT handle cache — avoids rebuilding the handle object on every
-        # `__getitem__`. Keyed by `(shard, frozenset(load_keys))` so a runtime flip of
+        # JNRT handle cache — avoids rebuilding the handle object on every `__getitem__`.
+        # Keyed by `(shard, frozenset(load_keys))` so a runtime flip of
         # `config.include_numeric_value` / `include_time_delta` naturally invalidates.
         # Dropped on pickle (see `__getstate__`) so `DataLoader(num_workers>0)` workers
         # rebuild their own cache rather than trying to serialize a safetensors handle
         # that doesn't round-trip through pickle.
-        self._jnrt_by_shard: dict[tuple[str, frozenset[str]], JointNestedRaggedTensorDict] = {}
+        self._jnrt_cache: dict[tuple[str, frozenset[str]], JointNestedRaggedTensorDict] = {}
 
     def __getstate__(self) -> dict:
         state = self.__dict__.copy()
-        state["_jnrt_by_shard"] = {}
+        state["_jnrt_cache"] = {}
         return state
 
     def __setstate__(self, state: dict) -> None:
@@ -1181,13 +1181,13 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
 
             >>> cfg = MEDSTorchDataConfig(tensorized_cohort_dir=tensorized_MEDS_dataset, max_seq_len=5)
             >>> fresh = MEDSPytorchDataset(cfg, split="train")
-            >>> fresh._jnrt_by_shard
+            >>> fresh._jnrt_cache
             {}
             >>> _ = fresh.load_subject_data(239684, 0, 3)
-            >>> len(fresh._jnrt_by_shard)
+            >>> len(fresh._jnrt_cache)
             1
             >>> _ = fresh.load_subject_data(239684, 0, 3)  # same shard, cache reused
-            >>> len(fresh._jnrt_by_shard)
+            >>> len(fresh._jnrt_cache)
             1
 
             Pickling the dataset (as `DataLoader(num_workers>0)` does when spawning workers)
@@ -1196,10 +1196,10 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
 
             >>> import pickle
             >>> roundtripped = pickle.loads(pickle.dumps(fresh))
-            >>> roundtripped._jnrt_by_shard
+            >>> roundtripped._jnrt_cache
             {}
             >>> _ = roundtripped.load_subject_data(239684, 0, 3)
-            >>> len(roundtripped._jnrt_by_shard)
+            >>> len(roundtripped._jnrt_cache)
             1
         """
         shard, subject_idx = self.subj_locations[subject_id]
@@ -1213,11 +1213,11 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
         if self.config.include_time_delta:
             load_keys.add("time_delta_days")
         cache_key = (shard, frozenset(load_keys))
-        jnrt = self._jnrt_by_shard.get(cache_key)
+        jnrt = self._jnrt_cache.get(cache_key)
         if jnrt is None:
             dynamic_data_fp = self.config.tensorized_cohort_dir / "data" / f"{shard}.nrt"
             jnrt = JointNestedRaggedTensorDict(tensors_fp=dynamic_data_fp, keys=load_keys)
-            self._jnrt_by_shard[cache_key] = jnrt
+            self._jnrt_cache[cache_key] = jnrt
         subject_dynamic_data = jnrt[subject_idx, st:end]
 
         # When `static_inclusion_mode == OMIT` the static columns were not loaded from the

--- a/src/meds_torchdata/pytorch_dataset.py
+++ b/src/meds_torchdata/pytorch_dataset.py
@@ -316,6 +316,22 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
         if self.config.seq_sampling_strategy == SubsequenceSamplingStrategy.STEP_THROUGH:
             self._expand_index_for_step_through()
 
+        # Per-shard JNRT handle cache — avoids rebuilding the handle object on every
+        # `__getitem__`. Keyed by `(shard, frozenset(load_keys))` so a runtime flip of
+        # `config.include_numeric_value` / `include_time_delta` naturally invalidates.
+        # Dropped on pickle (see `__getstate__`) so `DataLoader(num_workers>0)` workers
+        # rebuild their own cache rather than trying to serialize a safetensors handle
+        # that doesn't round-trip through pickle.
+        self._jnrt_by_shard: dict[tuple[str, frozenset[str]], JointNestedRaggedTensorDict] = {}
+
+    def __getstate__(self) -> dict:
+        state = self.__dict__.copy()
+        state["_jnrt_by_shard"] = {}
+        return state
+
+    def __setstate__(self, state: dict) -> None:
+        self.__dict__.update(state)
+
     def _expand_index_for_step_through(self) -> None:
         """Expand `self.index` so that STEP_THROUGH sampling produces one entry per window.
 
@@ -1158,10 +1174,35 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
             >>> static_data is None
             True
             >>> sample_pytorch_dataset.config.static_inclusion_mode = StaticInclusionMode.INCLUDE
+
+            The JNRT handle is cached per `(shard, load_keys)` on the dataset instance, so
+            repeated calls that hit the same shard reuse one handle rather than rebuilding
+            the safetensors wrapper each time:
+
+            >>> cfg = MEDSTorchDataConfig(tensorized_cohort_dir=tensorized_MEDS_dataset, max_seq_len=5)
+            >>> fresh = MEDSPytorchDataset(cfg, split="train")
+            >>> fresh._jnrt_by_shard
+            {}
+            >>> _ = fresh.load_subject_data(239684, 0, 3)
+            >>> len(fresh._jnrt_by_shard)
+            1
+            >>> _ = fresh.load_subject_data(239684, 0, 3)  # same shard, cache reused
+            >>> len(fresh._jnrt_by_shard)
+            1
+
+            Pickling the dataset (as `DataLoader(num_workers>0)` does when spawning workers)
+            drops the cache so each worker rebuilds its own handles — safetensors file
+            handles don't round-trip cleanly through pickle and would break otherwise:
+
+            >>> import pickle
+            >>> roundtripped = pickle.loads(pickle.dumps(fresh))
+            >>> roundtripped._jnrt_by_shard
+            {}
+            >>> _ = roundtripped.load_subject_data(239684, 0, 3)
+            >>> len(roundtripped._jnrt_by_shard)
+            1
         """
         shard, subject_idx = self.subj_locations[subject_id]
-
-        dynamic_data_fp = self.config.tensorized_cohort_dir / "data" / f"{shard}.nrt"
 
         # Only load the tensors downstream collation will actually use — `keys=` (nested_ragged_tensors
         # >= 0.2) skips the unloaded tensors' disk reads entirely. `code` is always required; the
@@ -1171,9 +1212,13 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
             load_keys.add("numeric_value")
         if self.config.include_time_delta:
             load_keys.add("time_delta_days")
-        subject_dynamic_data = JointNestedRaggedTensorDict(tensors_fp=dynamic_data_fp, keys=load_keys)[
-            subject_idx, st:end
-        ]
+        cache_key = (shard, frozenset(load_keys))
+        jnrt = self._jnrt_by_shard.get(cache_key)
+        if jnrt is None:
+            dynamic_data_fp = self.config.tensorized_cohort_dir / "data" / f"{shard}.nrt"
+            jnrt = JointNestedRaggedTensorDict(tensors_fp=dynamic_data_fp, keys=load_keys)
+            self._jnrt_by_shard[cache_key] = jnrt
+        subject_dynamic_data = jnrt[subject_idx, st:end]
 
         # When `static_inclusion_mode == OMIT` the static columns were not loaded from the
         # schema parquet (see issue #45 — skipping them at `pl.read_parquet(columns=...)`

--- a/tests/test_pytorch_dataset_properties.py
+++ b/tests/test_pytorch_dataset_properties.py
@@ -1,3 +1,4 @@
+import dataclasses
 from datetime import datetime, timedelta
 
 import numpy as np
@@ -196,8 +197,7 @@ def test_get_task_seq_bounds_and_labels_unlabeled(data):
 @given(st.data())
 @settings(max_examples=25, deadline=None)
 def test_schema_df_last_observed(sample_dataset_config_with_index, data):
-    cfg = sample_dataset_config_with_index
-    cfg.include_window_last_observed_in_schema = True
+    cfg = dataclasses.replace(sample_dataset_config_with_index, include_window_last_observed_in_schema=True)
     dataset = MEDSPytorchDataset(cfg, split="train")
 
     idx = data.draw(st.integers(min_value=0, max_value=len(dataset) - 1))
@@ -244,9 +244,11 @@ def test_get_task_seq_bounds_and_labels_semantic(data):
 
 
 def test_getitem_consistency(sample_dataset_config_with_index):
-    cfg = sample_dataset_config_with_index
-    cfg.include_window_last_observed_in_schema = True
-    cfg.batch_mode = BatchMode.SEM
+    cfg = dataclasses.replace(
+        sample_dataset_config_with_index,
+        include_window_last_observed_in_schema=True,
+        batch_mode=BatchMode.SEM,
+    )
     dataset = MEDSPytorchDataset(cfg, split="train")
 
     for idx in range(len(dataset)):

--- a/uv.lock
+++ b/uv.lock
@@ -858,7 +858,7 @@ requires-dist = [
     { name = "mkdocs-section-index", marker = "extra == 'docs'", specifier = "==0.3.9" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = "==0.28.2" },
     { name = "mkdocstrings-shell", marker = "extra == 'docs'", specifier = "~=1.0" },
-    { name = "nested-ragged-tensors", specifier = ">=0.2,<0.3" },
+    { name = "nested-ragged-tensors", specifier = ">=0.3,<0.4" },
     { name = "numpy", specifier = ">=1.26,<3" },
     { name = "omegaconf", specifier = ">=2.3" },
     { name = "polars", specifier = ">=1.30,<2" },
@@ -1258,15 +1258,15 @@ wheels = [
 
 [[package]]
 name = "nested-ragged-tensors"
-version = "0.2.0"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "safetensors" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/77/c617064470f8d9e9979d6d46478e097b4530aa4acad6b158760592f083fc/nested_ragged_tensors-0.2.0.tar.gz", hash = "sha256:656a76b7aa104dae62be331dc1bc086bc3e43fe93858ec3e9ab2edaac10dea93", size = 24356901, upload-time = "2026-04-18T11:56:52.472Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/8f/d93d1380cbfa89f0c6406636080a8dfc271a374c9aaf82b4e31611bd108e/nested_ragged_tensors-0.3.0.tar.gz", hash = "sha256:eeb0db59981d5bcc67ac1a16231593ef9ac267b5bc64ca311fab7460c7d7eca2", size = 24365067, upload-time = "2026-04-20T21:22:38.229Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/10/e7237fe2bcfa939950d05db92d2023a65b70ffb16d814de304cabf234140/nested_ragged_tensors-0.2.0-py3-none-any.whl", hash = "sha256:907f5f753b28893d0a7b6e1b06ecb5fea6ed6e4145bf4caa0938515cb5b562e8", size = 21887, upload-time = "2026-04-18T11:56:50.035Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/5a/e1a90df81cd3ff9440891e8f8ffad29838725fe791c772295e255f25100b/nested_ragged_tensors-0.3.0-py3-none-any.whl", hash = "sha256:0cb2d1dc23fcd9b04c9258625427eb00d1ef0d6d168255814a2e29d28f87aca7", size = 28473, upload-time = "2026-04-20T21:22:35.516Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Release candidate: `dev` → `main` for **v0.9.0**. Three PRs since 0.8.2:

### Perf (transparent)

- **#106** — Cache the JNRT handle per `(shard, frozenset(load_keys))` on `MEDSPytorchDataset` so `__getitem__` doesn't rebuild the safetensors wrapper on every call. Measured ~17.5% reduction in `dataset[0]` wall time on the fixture. Composes with the upstream `nested_ragged_tensors` per-access `safe_open` fix ([mmcdermott/nested_ragged_tensors#70](https://github.com/mmcdermott/nested_ragged_tensors/issues/70)).

### New features / new public API

- **#107** — Added `persistent_workers: bool | None = None` and `prefetch_factor: int | None = None` kwargs to `Datamodule`. Auto-enables `persistent_workers=True` when `num_workers > 0` (strict improvement — saves worker re-spawn + `MEDSPytorchDataset.__init__` cost per epoch). Fully overridable. `num_workers` and `pin_memory` intentionally left without magic defaults ([discussion](https://github.com/mmcdermott/meds-torch-data/issues/102#issuecomment-4280201132)).
- **#109** — `MEDSTorchDataConfig` gains `lock()` / `unlock()` methods. `MEDSPytorchDataset.__init__` now auto-locks the config on handoff; post-handoff `cfg.field = value` raises `RuntimeError` with migration guidance. `unlock()` is available as a loudly-warned escape hatch. Closes #81.

### Behavior changes

- **`persistent_workers` default flips from `False` → `True` when `num_workers > 0`** via `Datamodule`. Motivated by perf; user-overridable. Memory cost is per-worker `schema_dfs_by_shard` copy held across epochs.
- **Config mutation after dataset handoff now raises.** Pre-handoff mutation unchanged; post-handoff mutation was previously a silent-failure surface (#81), now raises with `dataclasses.replace` + fresh dataset as the migration path. `unlock()` exists for the rare legitimate cases.

### Docs

- Top-of-README callout added explaining config lock semantics.
- `Datamodule` docstring documents all four DataLoader kwargs (`num_workers`, `pin_memory`, `persistent_workers`, `prefetch_factor`) with rationale for when to tune each.
- `load_subject_data`, `collate`, `get_dataloader`, and 9 README examples migrated from in-place `cfg.field = value` mutation to `dataclasses.replace(cfg, field=value)` + fresh `MEDSPytorchDataset(cfg, ...)`.

## Migration guide

```python
# Before 0.9.0
cfg = MEDSTorchDataConfig(...)
pyd = MEDSPytorchDataset(cfg, split="train")
cfg.max_seq_len = 100  # silently took effect in SOME code paths, silently failed in others

# 0.9.0 and later
import dataclasses
cfg = MEDSTorchDataConfig(...)
pyd = MEDSPytorchDataset(cfg, split="train")
cfg.max_seq_len = 100  # RuntimeError: Cannot mutate `max_seq_len` on a locked config...

# Correct idiom:
cfg2 = dataclasses.replace(cfg, max_seq_len=100)
pyd2 = MEDSPytorchDataset(cfg2, split="train")
```

## Test plan

- [x] All three feature PRs merged to `dev` with CI green
- [x] Deep review prior to this RC:
  - [x] No stale doc references (`_jnrt_by_shard`, `parallelized`, `_handed_off_to_dataset` all absent; `frozen` references only in the unrelated `MEDSTorchBatch` dict context)
  - [x] Config lock does not leak `_locked` into `save_hyperparameters` / `dataclasses.asdict` (not a dataclass field)
  - [x] JNRT cache key unaffected by the lock flag
  - [x] `Datamodule` cached_property + idempotent lock verified (multiple datasets share locked cfg cleanly)
  - [x] Pickle roundtrip of locked config preserves the lock — pinned in doctest via #110
- [ ] CI green on this PR

## Version

setuptools-scm + git tag. Tag `0.9.0` on merge commit triggers PyPI publish via `.github/workflows/release.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
