### PR TITLE
Lock cfg only after dataset init succeeds (RC polish)

### DIFF
--- a/src/meds_torchdata/config.py
+++ b/src/meds_torchdata/config.py
@@ -577,6 +577,19 @@ class MEDSTorchDataConfig:
             Traceback (most recent call last):
                 ...
             RuntimeError: Cannot mutate `max_seq_len` on a locked MEDSTorchDataConfig...
+
+            If `MEDSPytorchDataset.__init__` raises partway through (e.g., the caller asks
+            for a split that has no schema files), the lock is not applied — the caller is
+            free to fix up the cfg and retry without `unlock()`-ing first:
+
+            >>> cfg = MEDSTorchDataConfig(tensorized_cohort_dir=tensorized_MEDS_dataset, max_seq_len=5)
+            >>> try:
+            ...     MEDSPytorchDataset(cfg, split="nonexistent_split")
+            ... except FileNotFoundError:
+            ...     pass
+            >>> cfg.max_seq_len = 42  # no error, cfg is still mutable
+            >>> cfg.max_seq_len
+            42
         """
         object.__setattr__(self, "_locked", True)
 

--- a/src/meds_torchdata/pytorch_dataset.py
+++ b/src/meds_torchdata/pytorch_dataset.py
@@ -233,10 +233,6 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
     def __init__(self, cfg: MEDSTorchDataConfig, split: str):
         super().__init__()
 
-        # Lock the cfg against further mutation while it's attached to this dataset — see
-        # `MEDSTorchDataConfig.lock()` / `unlock()` for the full contract and escape hatch.
-        cfg.lock()
-
         self.config: MEDSTorchDataConfig = cfg
         self.split: str = split
 
@@ -335,6 +331,12 @@ class MEDSPytorchDataset(torch.utils.data.Dataset):
         # (another optional tensor, mode-specific file selection, etc.), the cache key
         # must expand to match — otherwise stale entries will be served.
         self._jnrt_cache: dict[tuple[str, frozenset[str]], JointNestedRaggedTensorDict] = {}
+
+        # Lock the cfg only after init has fully succeeded — if any of the above raises
+        # (missing schema, column mismatch, etc.), the caller keeps a mutable cfg and can
+        # retry or modify without having to `unlock()` first. See `MEDSTorchDataConfig.lock()`
+        # / `unlock()` for the full contract and escape hatch.
+        cfg.lock()
 
     def __getstate__(self) -> dict:
         state = self.__dict__.copy()


### PR DESCRIPTION
## Summary

Copilot review on RC #111 flagged that `MEDSPytorchDataset.__init__` was calling `cfg.lock()` at the top of init. If anything later in init raises (missing schema files, cohort-missing-`measurements_per_event` under STEP_THROUGH+SM, etc.), the caller is left with a locked cfg but no dataset — and to retry with the same cfg they'd have to `unlock()` first (which emits a loud warning).

Fix: move `cfg.lock()` to the end of `__init__`. The lock only takes effect when the dataset was actually constructed. No exception handling needed — it's just a reordering.

Doctest on `MEDSTorchDataConfig.lock()` pins the new behavior: a failed construction leaves the cfg mutable so callers can fix it up and retry cleanly.

## Test plan

- [x] `uv run pytest --no-cov` — 85 tests pass (one new doctest)
- [x] `uv run pre-commit run` — clean
- [ ] CI green on push

Addresses the Copilot review comment on #111 ([link](https://github.com/mmcdermott/meds-torch-data/pull/111#discussion_r3112440480)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)